### PR TITLE
fboemer/he-backend

### DIFF
--- a/external/external_seal.cmake
+++ b/external/external_seal.cmake
@@ -25,7 +25,7 @@ ExternalProject_Add(
     ext_seal
     URL ${SEAL_TAR_FILE}
     PREFIX ${SEAL_PREFIX}
-    CONFIGURE_COMMAND cd ${SEAL_SRC_DIR} && ./configure --prefix=${NGRAPH_HE_INSTALL_DIR}
+    CONFIGURE_COMMAND cd ${SEAL_SRC_DIR} && ./configure CXXFLAGS=-fPIC --prefix=${NGRAPH_HE_INSTALL_DIR}
     BUILD_COMMAND make -j$(nproc) -C ${SEAL_SRC_DIR}
     INSTALL_COMMAND make install -C ${SEAL_SRC_DIR}
         && cp -r ${NGRAPH_HE_INSTALL_INCLUDE_DIR}/SEAL/seal ${NGRAPH_HE_INSTALL_INCLUDE_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,13 +33,17 @@ include_directories(
     SYSTEM
     ${EXTERNAL_NGRAPH_INCLUDE_DIR}
     ${HE_TRANSFORMER_INCLUDE_DIR}
+    ${NGRAPH_HE_INSTALL_INCLUDE_DIR}
 )
+
+link_directories(${NGRAPH_HE_INSTALL_LIB_DIR})
 
 # Target library
 add_library(he SHARED ${HE_SRC})
 install(TARGETS he DESTINATION ${NGRAPH_HE_INSTALL_LIB_DIR})
 
 add_dependencies(he ext_heaan ext_seal)
+target_link_libraries(he seal)
 
 # Installs header make `make install`
 install(DIRECTORY

--- a/src/he_backend.hpp
+++ b/src/he_backend.hpp
@@ -21,6 +21,7 @@
 
 #include "ngraph/function.hpp"
 #include "ngraph/runtime/backend.hpp"
+#include "seal/seal.h"
 
 namespace ngraph
 {
@@ -54,6 +55,9 @@ namespace ngraph
                           const std::vector<std::shared_ptr<runtime::TensorView>>& inputs) override;
 
                 void remove_compiled_function(std::shared_ptr<Function> func) override;
+
+            private:
+                seal::EncryptionParameters params;
             };
         }
     }


### PR DESCRIPTION
For he-backend, we  would want to include "seal/seal.h". To enable this, we move the current he_install/include/SEAL/seal/seal.h to he_install/include/seal/seal.h.
Also adds seal::EncryptionParams to he_backend. 