### PR TITLE
Fixed broadcast to prefer plaintext

### DIFF
--- a/src/kernel/broadcast.cpp
+++ b/src/kernel/broadcast.cpp
@@ -23,12 +23,13 @@
 
 using namespace std;
 using namespace ngraph;
-
-void runtime::he::kernel::broadcast(const vector<shared_ptr<seal::Ciphertext>>& arg,
-                                    vector<shared_ptr<seal::Ciphertext>>& out,
-                                    const Shape& in_shape,
-                                    const Shape& out_shape,
-                                    const AxisSet& broadcast_axes)
+/*
+template <typename S, typename T>
+void runtime::he::kernel::broadcast(const vector<shared_ptr<S>>& arg,
+            vector<shared_ptr<T>>& out,
+            const Shape& in_shape,
+            const Shape& out_shape,
+            const AxisSet& broadcast_axes)
 {
     CoordinateTransform input_transform(in_shape);
     CoordinateTransform output_transform(out_shape);
@@ -38,6 +39,24 @@ void runtime::he::kernel::broadcast(const vector<shared_ptr<seal::Ciphertext>>& 
 
         out[output_transform.index(output_coord)] = arg[input_transform.index(input_coord)];
     }
+} */
+
+void runtime::he::kernel::broadcast(const vector<shared_ptr<seal::Ciphertext>>& arg,
+                                    vector<shared_ptr<seal::Ciphertext>>& out,
+                                    const Shape& in_shape,
+                                    const Shape& out_shape,
+                                    const AxisSet& broadcast_axes)
+{
+    broadcast<seal::Ciphertext, seal::Ciphertext>(arg, out, in_shape, out_shape, broadcast_axes);
+}
+
+void runtime::he::kernel::broadcast(const vector<shared_ptr<seal::Plaintext>>& arg,
+                                    vector<shared_ptr<seal::Plaintext>>& out,
+                                    const Shape& in_shape,
+                                    const Shape& out_shape,
+                                    const AxisSet& broadcast_axes)
+{
+    broadcast<seal::Plaintext, seal::Plaintext>(arg, out, in_shape, out_shape, broadcast_axes);
 }
 
 void runtime::he::kernel::broadcast(const vector<shared_ptr<seal::Plaintext>>& arg,

--- a/src/kernel/broadcast.hpp
+++ b/src/kernel/broadcast.hpp
@@ -29,8 +29,32 @@ namespace ngraph
 
             namespace kernel
             {
+                template <typename S, typename T>
+                void broadcast(const vector<shared_ptr<S>>& arg,
+                               vector<shared_ptr<T>>& out,
+                               const Shape& in_shape,
+                               const Shape& out_shape,
+                               const AxisSet& broadcast_axes)
+                {
+                    CoordinateTransform input_transform(in_shape);
+                    CoordinateTransform output_transform(out_shape);
+                    for (const Coordinate& output_coord : output_transform)
+                    {
+                        Coordinate input_coord = project(output_coord, broadcast_axes);
+
+                        out[output_transform.index(output_coord)] =
+                            arg[input_transform.index(input_coord)];
+                    }
+                };
+
                 void broadcast(const vector<shared_ptr<seal::Ciphertext>>& arg0,
                                vector<shared_ptr<seal::Ciphertext>>& out,
+                               const Shape& in_shape,
+                               const Shape& out_shape,
+                               const AxisSet& broadcast_axes);
+
+                void broadcast(const vector<shared_ptr<seal::Plaintext>>& arg0,
+                               vector<shared_ptr<seal::Plaintext>>& out,
                                const Shape& in_shape,
                                const Shape& out_shape,
                                const AxisSet& broadcast_axes);


### PR DESCRIPTION
With some exported ngraph graphs, we see Constant -> Broadcast -> Dot
The constant is a plaintext, but the broadcast op always outputs a ciphertext, causing unnecessary encryption.

Before, it took 33 seconds to perform this broadcast:
```
[INFO] 2018-05-04T17:32:39z he_call_frame.cpp 138	Op Broadcast_32
[INFO] 2018-05-04T17:32:39z he_call_frame.cpp 458	Broadcast plain -> cipher
[INFO] 2018-05-04T17:33:12z he_call_frame.cpp 138	Op Broadcast_33
```
After, it takes <1 second:
```
[INFO] 2018-05-04T17:49:03z he_call_frame.cpp 154	Op Broadcast_32
[INFO] 2018-05-04T17:49:03z he_call_frame.cpp 486	Broadcast plain plain
[INFO] 2018-05-04T17:49:03z he_call_frame.cpp 154	Op Broadcast_33
```
