### PR TITLE
Fboemer/faster plain mult

### DIFF
--- a/src/he_executable.cpp
+++ b/src/he_executable.cpp
@@ -685,6 +685,7 @@ void runtime::he::HEExecutable::generate_calls(
 
   // TODO: move to static function
   auto lazy_rescaling = [this](auto& cipher) {
+    // NGRAPH_INFO << "Lazy rescaling";
     auto he_seal_backend =
         runtime::he::he_seal::cast_to_seal_backend(m_he_backend);
 #pragma omp parallel for

--- a/src/seal/bfv/unit_test.manifest
+++ b/src/seal/bfv/unit_test.manifest
@@ -79,3 +79,4 @@ add_optimized_2_3
 sub_2_3
 
 cipher_tv_batch_write_read_2_1
+multiply_2_3_halves

--- a/src/seal/ckks/kernel/add_seal_ckks.cpp
+++ b/src/seal/ckks/kernel/add_seal_ckks.cpp
@@ -33,6 +33,9 @@ void he_seal::ckks::kernel::scalar_add_ckks(
     const seal::MemoryPoolHandle& pool) {
   NGRAPH_ASSERT(arg0->complex_packing() == arg1->complex_packing());
 
+  NGRAPH_INFO << "Adding C+C at scale " << arg0->m_ciphertext.scale() << ",  "
+              << arg1->m_ciphertext.scale();
+
   match_modulus_and_scale_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
                                   pool);
   he_seal_ckks_backend->get_evaluator()->add(

--- a/src/seal/ckks/kernel/add_seal_ckks.cpp
+++ b/src/seal/ckks/kernel/add_seal_ckks.cpp
@@ -33,9 +33,6 @@ void he_seal::ckks::kernel::scalar_add_ckks(
     const seal::MemoryPoolHandle& pool) {
   NGRAPH_ASSERT(arg0->complex_packing() == arg1->complex_packing());
 
-  NGRAPH_INFO << "Adding C+C at scale " << arg0->m_ciphertext.scale() << ",  "
-              << arg1->m_ciphertext.scale();
-
   match_modulus_and_scale_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
                                   pool);
   he_seal_ckks_backend->get_evaluator()->add(
@@ -53,12 +50,8 @@ void he_seal::ckks::kernel::scalar_add_ckks(
   if (arg1->is_single_value()) {
     float value = arg1->get_values()[0];
     double double_val = double(value);
-    NGRAPH_INFO << "Adding by double " << double_val << " at scale "
-                << arg0->m_ciphertext.scale();
     add_plain(arg0->m_ciphertext, double_val, out->m_ciphertext,
               he_seal_ckks_backend);
-    NGRAPH_INFO << "Done adding by double. out scale "
-                << out->m_ciphertext.scale();
   } else {
     if (!arg1->is_encoded()) {
       // Just-in-time encoding at the right scale and modulus

--- a/src/seal/ckks/kernel/add_seal_ckks.cpp
+++ b/src/seal/ckks/kernel/add_seal_ckks.cpp
@@ -47,25 +47,36 @@ void he_seal::ckks::kernel::scalar_add_ckks(
     const element::Type& element_type,
     const he_seal::HESealCKKSBackend* he_seal_ckks_backend,
     const seal::MemoryPoolHandle& pool) {
-  if (!arg1->is_encoded()) {
-    // Just-in-time encoding at the right scale and modulus
-    he_seal_ckks_backend->encode(arg1, arg0->m_ciphertext.parms_id(),
-                                 arg0->m_ciphertext.scale(),
-                                 arg0->complex_packing());
+  if (arg1->is_single_value()) {
+    float value = arg1->get_values()[0];
+    double double_val = double(value);
+    NGRAPH_INFO << "Adding by double " << double_val << " at scale "
+                << arg0->m_ciphertext.scale();
+    add_plain(arg0->m_ciphertext, double_val, out->m_ciphertext,
+              he_seal_ckks_backend);
+    NGRAPH_INFO << "Done adding by double. out scale "
+                << out->m_ciphertext.scale();
   } else {
-    // Shouldn't be needed?
-    // match_modulus_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
-    // pool);
-    match_scale(arg0.get(), arg1.get(), he_seal_ckks_backend);
-  }
-  size_t chain_ind0 = get_chain_index(arg0.get(), he_seal_ckks_backend);
-  size_t chain_ind1 = get_chain_index(arg1.get(), he_seal_ckks_backend);
-  NGRAPH_ASSERT(chain_ind0 == chain_ind1)
-      << "Chain inds " << chain_ind0 << ",  " << chain_ind1 << " don't match";
+    if (!arg1->is_encoded()) {
+      // Just-in-time encoding at the right scale and modulus
+      he_seal_ckks_backend->encode(arg1, arg0->m_ciphertext.parms_id(),
+                                   arg0->m_ciphertext.scale(),
+                                   arg0->complex_packing());
+    } else {
+      // Shouldn't be needed?
+      // match_modulus_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
+      // pool);
+      match_scale(arg0.get(), arg1.get(), he_seal_ckks_backend);
+    }
+    size_t chain_ind0 = get_chain_index(arg0.get(), he_seal_ckks_backend);
+    size_t chain_ind1 = get_chain_index(arg1.get(), he_seal_ckks_backend);
+    NGRAPH_ASSERT(chain_ind0 == chain_ind1)
+        << "Chain inds " << chain_ind0 << ",  " << chain_ind1 << " don't match";
 
-  he_seal_ckks_backend->get_evaluator()->add_plain(
-      arg0->m_ciphertext, arg1->get_plaintext(), out->m_ciphertext);
-  out->set_complex_packing(arg0->complex_packing());
+    he_seal_ckks_backend->get_evaluator()->add_plain(
+        arg0->m_ciphertext, arg1->get_plaintext(), out->m_ciphertext);
+    out->set_complex_packing(arg0->complex_packing());
+  }
 }
 
 void he_seal::ckks::kernel::scalar_add_ckks(

--- a/src/seal/ckks/kernel/multiply_seal_ckks.cpp
+++ b/src/seal/ckks/kernel/multiply_seal_ckks.cpp
@@ -66,12 +66,8 @@ void he_seal::ckks::kernel::scalar_multiply_ckks(
   if (arg1->is_single_value()) {
     float value = arg1->get_values()[0];
     double double_val = double(value);
-    NGRAPH_INFO << "Multiply by double " << double_val << " at scale "
-                << arg0->m_ciphertext.scale();
     multiply_plain(arg0->m_ciphertext, double_val, out->m_ciphertext,
                    he_seal_ckks_backend, pool);
-    NGRAPH_INFO << "Done multiplying by double. out scale "
-                << out->m_ciphertext.scale();
   } else {
     NGRAPH_INFO << "Multiply by plain";
     if (!arg1->is_encoded()) {

--- a/src/seal/ckks/kernel/multiply_seal_ckks.cpp
+++ b/src/seal/ckks/kernel/multiply_seal_ckks.cpp
@@ -16,6 +16,7 @@
 
 #include "seal/ckks/kernel/multiply_seal_ckks.hpp"
 #include "seal/ckks/seal_ckks_util.hpp"
+#include "seal/seal.h"
 
 using namespace std;
 using namespace ngraph::runtime::he;
@@ -61,34 +62,42 @@ void he_seal::ckks::kernel::scalar_multiply_ckks(
     const element::Type& element_type,
     const runtime::he::he_seal::HESealCKKSBackend* he_seal_ckks_backend,
     const seal::MemoryPoolHandle& pool) {
-  if (!arg1->is_encoded()) {
-    // Just-in-time encoding at the right scale and modulus
-    he_seal_ckks_backend->encode(arg1, arg0->m_ciphertext.parms_id(),
-                                 arg0->m_ciphertext.scale(), false);
+  if (arg1->is_single_value()) {
+    NGRAPH_INFO << "Multiply by double";
+    float value = arg1->get_values()[0];
+    multiply_by_double(arg0->m_ciphertext, double(value), out->m_ciphertext,
+                       he_seal_ckks_backend, pool);
+    NGRAPH_INFO << "Done multiplying by double";
   } else {
-    // Shouldn't need to match modulus unless encoding went wrong
-    // match_modulus_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
-    // pool);
-    match_scale(arg0.get(), arg1.get(), he_seal_ckks_backend);
-  }
+    NGRAPH_INFO << "Multiply by plain";
+    size_t chain_ind0 = get_chain_index(arg0.get(), he_seal_ckks_backend);
+    size_t chain_ind1 = get_chain_index(arg1.get(), he_seal_ckks_backend);
 
-  size_t chain_ind0 = get_chain_index(arg0.get(), he_seal_ckks_backend);
-  size_t chain_ind1 = get_chain_index(arg1.get(), he_seal_ckks_backend);
+    NGRAPH_ASSERT(chain_ind0 == chain_ind1)
+        << "Chain_ind0 " << chain_ind0 << " != chain_ind1 " << chain_ind1;
+    NGRAPH_ASSERT(chain_ind0 > 0) << "Multiplicative depth exceeded for arg0";
+    NGRAPH_ASSERT(chain_ind1 > 0) << "Multiplicative depth exceeded for arg1";
 
-  NGRAPH_ASSERT(chain_ind0 == chain_ind1)
-      << "Chain_ind0 " << chain_ind0 << " != chain_ind1 " << chain_ind1;
-  NGRAPH_ASSERT(chain_ind0 > 0) << "Multiplicative depth exceeded for arg0";
-  NGRAPH_ASSERT(chain_ind1 > 0) << "Multiplicative depth exceeded for arg1";
-
-  try {
-    he_seal_ckks_backend->get_evaluator()->multiply_plain(
-        arg0->m_ciphertext, arg1->get_plaintext(), out->m_ciphertext, pool);
-  } catch (const std::exception& e) {
-    NGRAPH_INFO << "Error multiplying plain " << e.what();
-    NGRAPH_INFO << "arg1->get_values().size() " << arg1->get_values().size();
-    auto& values = arg1->get_values();
-    for (const auto& elem : values) {
-      NGRAPH_INFO << elem;
+    if (!arg1->is_encoded()) {
+      // Just-in-time encoding at the right scale and modulus
+      he_seal_ckks_backend->encode(arg1, arg0->m_ciphertext.parms_id(),
+                                   arg0->m_ciphertext.scale(), false);
+    } else {
+      // Shouldn't need to match modulus unless encoding went wrong
+      // match_modulus_inplace(arg0.get(), arg1.get(), he_seal_ckks_backend,
+      // pool);
+      match_scale(arg0.get(), arg1.get(), he_seal_ckks_backend);
+    }
+    try {
+      he_seal_ckks_backend->get_evaluator()->multiply_plain(
+          arg0->m_ciphertext, arg1->get_plaintext(), out->m_ciphertext, pool);
+    } catch (const std::exception& e) {
+      NGRAPH_INFO << "Error multiplying plain " << e.what();
+      NGRAPH_INFO << "arg1->get_values().size() " << arg1->get_values().size();
+      auto& values = arg1->get_values();
+      for (const auto& elem : values) {
+        NGRAPH_INFO << elem;
+      }
     }
   }
   out->set_complex_packing(arg0->complex_packing());

--- a/src/seal/ckks/seal_ckks_util.cpp
+++ b/src/seal/ckks/seal_ckks_util.cpp
@@ -111,9 +111,6 @@ void runtime::he::he_seal::ckks::encode(
   bool is_negative = std::signbit(coeffd);
   coeffd = fabs(coeffd);
 
-  NGRAPH_INFO << "Encoding double " << value << " at scale " << scale
-              << " => coeffd = " << coeffd;
-
   // Use faster decomposition methods when possible
   if (coeff_bit_count <= 64) {
     uint64_t coeffu = static_cast<uint64_t>(fabs(coeffd));
@@ -229,10 +226,6 @@ void runtime::he::he_seal::ckks::encode(
       }
     }
   }
-  NGRAPH_INFO << "Encoded vals ";
-  for (const auto& elem : destination) {
-    NGRAPH_INFO << elem;
-  }
 }
 
 void runtime::he::he_seal::ckks::add_plain_inplace(
@@ -263,7 +256,6 @@ void runtime::he::he_seal::ckks::add_plain_inplace(
   }
 
   NGRAPH_INFO << "Adding double " << value << " at scale " << encrypted.scale();
-  NGRAPH_INFO << "coeff_count " << coeff_count;
   NGRAPH_ASSERT(encrypted.data() != nullptr) << "Encrypted data == nullptr";
 
   // Encode
@@ -354,7 +346,6 @@ void runtime::he::he_seal::ckks::multiply_plain_inplace(
 
   // Set the scale
   encrypted.scale() = new_scale;
-  NGRAPH_INFO << "encrypted scale after mult " << encrypted.scale();
 
 #ifndef SEAL_ALLOW_TRANSPARENT_CIPHERTEXT
   // Transparent ciphertext output is not allowed.

--- a/src/seal/ckks/seal_ckks_util.cpp
+++ b/src/seal/ckks/seal_ckks_util.cpp
@@ -255,7 +255,6 @@ void runtime::he::he_seal::ckks::add_plain_inplace(
     throw ngraph_error("invalid parameters");
   }
 
-  NGRAPH_INFO << "Adding double " << value << " at scale " << encrypted.scale();
   NGRAPH_ASSERT(encrypted.data() != nullptr) << "Encrypted data == nullptr";
 
   // Encode
@@ -265,7 +264,6 @@ void runtime::he::he_seal::ckks::add_plain_inplace(
                                      plaintext_vals, he_seal_ckks_backend);
 
   for (size_t j = 0; j < coeff_mod_count; j++) {
-    NGRAPH_INFO << "Adding poly coeff " << j;
     // Add poly scalar instead of poly poly
     runtime::he::he_seal::ckks::add_poly_scalar_coeffmod(
         encrypted.data() + (j * coeff_count), coeff_count, plaintext_vals[j],

--- a/src/seal/ckks/seal_ckks_util.cpp
+++ b/src/seal/ckks/seal_ckks_util.cpp
@@ -60,62 +60,59 @@ void runtime::he::he_seal::ckks::match_modulus_and_scale_inplace(
   }
 }
 
-void runtime::he::he_seal::ckks::multiply_by_double_inplace(
-    seal::Ciphertext& encrypted, double value,
+// Encode value into vector of coefficients
+void runtime::he::he_seal::ckks::encode(
+    double value, double scale, seal::parms_id_type parms_id,
+    std::vector<std::uint64_t>& destination,
     const HESealCKKSBackend* he_seal_ckks_backend,
     seal::MemoryPoolHandle pool) {
   // Verify parameters.
   auto context = he_seal_ckks_backend->get_context();
-  if (!encrypted.is_metadata_valid_for(context)) {
-    throw ngraph_error("encrypted is not valid for encryption parameters");
-  }
-  if (!context->context_data(encrypted.parms_id())) {
-    throw ngraph_error("encrypted is not valid for encryption parameters");
-  }
-  if (!encrypted.is_ntt_form()) {
-    throw ngraph_error("encrypted is not NTT form");
+  auto context_data_ptr = context->context_data(parms_id);
+  if (!context_data_ptr) {
+    throw ngraph_error("parms_id is not valid for encryption parameters");
   }
   if (!pool) {
     throw ngraph_error("pool is uninitialized");
   }
 
-  // Extract encryption parameters.
-  auto& context_data = *context->context_data(encrypted.parms_id());
+  auto& context_data = *context_data_ptr;
   auto& parms = context_data.parms();
   auto& coeff_modulus = parms.coeff_modulus();
-  size_t coeff_count = parms.poly_modulus_degree();
   size_t coeff_mod_count = coeff_modulus.size();
-  size_t encrypted_ntt_size = encrypted.size();
+  size_t coeff_count = parms.poly_modulus_degree();
 
-  // Size check
-  if (!seal::util::product_fits_in(encrypted_ntt_size, coeff_count,
-                                   coeff_mod_count)) {
-    throw ngraph_error("invalid parameters");
-  }
   // Quick sanity check
   if (!seal::util::product_fits_in(coeff_mod_count, coeff_count)) {
     throw ngraph_error("invalid parameters");
   }
 
-  // TODO: explore using different scales! Smaller scales might reduce # of
-  // rescalings
-  double scale = encrypted.scale();
-  double new_scale = scale * scale;
-
-  // "Encode" the double at same scale
-  std::vector<std::int64_t> plaintext_vals(coeff_mod_count, 0);
+  // Check that scale is positive and not too large
+  if (scale <= 0 || (static_cast<int>(log2(scale)) >=
+                     context_data.total_coeff_modulus_bit_count())) {
+    throw ngraph_error("scale out of bounds");
+  }
 
   // Compute the scaled value
   value *= scale;
+
   int coeff_bit_count = static_cast<int>(log2(fabs(value))) + 2;
   if (coeff_bit_count >= context_data.total_coeff_modulus_bit_count()) {
     throw ngraph_error("encoded value is too large");
   }
 
   double two_pow_64 = pow(2.0, 64);
+
+  // Resize destination to appropriate size
+  // TODO: use reserve?
+  destination.resize(coeff_mod_count);
+
   double coeffd = round(value);
   bool is_negative = std::signbit(coeffd);
   coeffd = fabs(coeffd);
+
+  NGRAPH_INFO << "Encoding double " << value << " at scale " << scale
+              << " => coeffd = " << coeffd;
 
   // Use faster decomposition methods when possible
   if (coeff_bit_count <= 64) {
@@ -123,7 +120,7 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
 
     if (is_negative) {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] = seal::util::negate_uint_mod(
+        destination[j] = seal::util::negate_uint_mod(
             coeffu % coeff_modulus[j].value(), coeff_modulus[j]);
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
         //       negate_uint_mod(coeffu % coeff_modulus[j].value(),
@@ -131,7 +128,7 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
       }
     } else {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] = coeffu % coeff_modulus[j].value();
+        destination[j] = coeffu % coeff_modulus[j].value();
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
         //       coeffu % coeff_modulus[j].value());
       }
@@ -142,7 +139,7 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
 
     if (is_negative) {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] = seal::util::negate_uint_mod(
+        destination[j] = seal::util::negate_uint_mod(
             seal::util::barrett_reduce_128(coeffu, coeff_modulus[j]),
             coeff_modulus[j]);
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
@@ -151,7 +148,7 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
       }
     } else {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] =
+        destination[j] =
             seal::util::barrett_reduce_128(coeffu, coeff_modulus[j]);
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
         //        barrett_reduce_128(coeffu, coeff_modulus[j]));
@@ -168,14 +165,13 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
           std::size_t coeff_mod_count = coeff_modulus.size();
 #ifdef SEAL_DEBUG
           if (value == nullptr) {
-            throw std::invalid_argument("value cannot be null");
+            throw ngraph_error("value cannot be null");
           }
           if (destination == nullptr) {
-            throw std::invalid_argument("destination cannot be null");
+            throw ngraph_error("destination cannot be null");
           }
           if (destination == value) {
-            throw std::invalid_argument(
-                "value cannot be the same as destination");
+            throw ngraph_error("value cannot be the same as destination");
           }
 #endif
           if (coeff_mod_count == 1) {
@@ -220,25 +216,133 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
     // Finally replace the sign if necessary
     if (is_negative) {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] =
+        destination[j] =
             seal::util::negate_uint_mod(decomp_coeffu[j], coeff_modulus[j]);
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
         //       negate_uint_mod(decomp_coeffu[j], coeff_modulus[j]));
       }
     } else {
       for (size_t j = 0; j < coeff_mod_count; j++) {
-        plaintext_vals[j] = decomp_coeffu[j];
+        destination[j] = decomp_coeffu[j];
         // fill_n(destination.data() + (j * coeff_count), coeff_count,
         //       decomp_coeffu[j]);
       }
     }
   }
-  // Done doing "encoding"
+  NGRAPH_INFO << "Encoded vals ";
+  for (const auto& elem : destination) {
+    NGRAPH_INFO << elem;
+  }
+}
 
+void runtime::he::he_seal::ckks::add_plain_inplace(
+    seal::Ciphertext& encrypted, double value,
+    const HESealCKKSBackend* he_seal_ckks_backend) {
+  // Verify parameters.
+  auto context = he_seal_ckks_backend->get_context();
+  if (!encrypted.is_metadata_valid_for(context)) {
+    throw ngraph_error("encrypted is not valid for encryption parameters");
+  }
+  auto& context_data = *context->context_data(encrypted.parms_id());
+  auto& parms = context_data.parms();
+
+  NGRAPH_ASSERT(parms.scheme() == seal::scheme_type::CKKS)
+      << "Scheme type must be CKKS";
+  if (parms.scheme() == seal::scheme_type::CKKS && !encrypted.is_ntt_form()) {
+    throw ngraph_error("CKKS encrypted must be in NTT form");
+  }
+
+  // Extract encryption parameters.
+  auto& coeff_modulus = parms.coeff_modulus();
+  size_t coeff_count = parms.poly_modulus_degree();
+  size_t coeff_mod_count = coeff_modulus.size();
+
+  // Size check
+  if (!seal::util::product_fits_in(coeff_count, coeff_mod_count)) {
+    throw ngraph_error("invalid parameters");
+  }
+
+  NGRAPH_INFO << "Adding double " << value << " at scale " << encrypted.scale();
+  NGRAPH_INFO << "coeff_count " << coeff_count;
+  NGRAPH_ASSERT(encrypted.data() != nullptr) << "Encrypted data == nullptr";
+
+  // Encode
+  std::vector<std::uint64_t> plaintext_vals(coeff_mod_count, 0);
+  double scale = encrypted.scale();
+  runtime::he::he_seal::ckks::encode(value, scale, parms.parms_id(),
+                                     plaintext_vals, he_seal_ckks_backend);
+
+  for (size_t j = 0; j < coeff_mod_count; j++) {
+    NGRAPH_INFO << "Adding poly coeff " << j;
+    // Add poly scalar instead of poly poly
+    runtime::he::he_seal::ckks::add_poly_scalar_coeffmod(
+        encrypted.data() + (j * coeff_count), coeff_count, plaintext_vals[j],
+        coeff_modulus[j], encrypted.data() + (j * coeff_count));
+    // seal::util::add_poly_poly_coeffmod(
+    //     encrypted.data() + (j * coeff_count),
+    //     plain.data() + (j * coeff_count), coeff_count, coeff_modulus[j],
+    //     encrypted.data() + (j * coeff_count));
+  }
+
+#ifndef SEAL_ALLOW_TRANSPARENT_CIPHERTEXT
+  // Transparent ciphertext output is not allowed.
+  if (encrypted.is_transparent()) {
+    throw ngraph_error("result ciphertext is transparent");
+  }
+#endif
+}
+
+void runtime::he::he_seal::ckks::multiply_plain_inplace(
+    seal::Ciphertext& encrypted, double value,
+    const HESealCKKSBackend* he_seal_ckks_backend,
+    seal::MemoryPoolHandle pool) {
+  // Verify parameters.
+  auto context = he_seal_ckks_backend->get_context();
+  if (!encrypted.is_metadata_valid_for(context)) {
+    throw ngraph_error("encrypted is not valid for encryption parameters");
+  }
+  if (!context->context_data(encrypted.parms_id())) {
+    throw ngraph_error("encrypted is not valid for encryption parameters");
+  }
+  if (!encrypted.is_ntt_form()) {
+    throw ngraph_error("encrypted is not NTT form");
+  }
+  if (!pool) {
+    throw ngraph_error("pool is uninitialized");
+  }
+
+  // Extract encryption parameters.
+  auto& context_data = *context->context_data(encrypted.parms_id());
+  auto& parms = context_data.parms();
+  auto& coeff_modulus = parms.coeff_modulus();
+  size_t coeff_count = parms.poly_modulus_degree();
+  size_t coeff_mod_count = coeff_modulus.size();
+  size_t encrypted_ntt_size = encrypted.size();
+
+  // Size check
+  if (!seal::util::product_fits_in(encrypted_ntt_size, coeff_count,
+                                   coeff_mod_count)) {
+    throw ngraph_error("invalid parameters");
+  }
+
+  std::vector<std::uint64_t> plaintext_vals(coeff_mod_count, 0);
+  // TODO: explore using different scales! Smaller scales might reduce # of
+  // rescalings
+  double scale = encrypted.scale();
+  runtime::he::he_seal::ckks::encode(value, scale, parms.parms_id(),
+                                     plaintext_vals, he_seal_ckks_backend);
+
+  double new_scale = scale * scale;
   // Check that scale is positive and not too large
   if (new_scale <= 0 || (static_cast<int>(log2(new_scale)) >=
                          context_data.total_coeff_modulus_bit_count())) {
     throw ngraph_error("scale out of bounds");
+  }
+
+  // Done doing "encoding"
+  NGRAPH_INFO << "Done fake encoding " << value << " at scale " << scale;
+  for (const auto& elem : plaintext_vals) {
+    NGRAPH_INFO << elem;
   }
 
   for (size_t i = 0; i < encrypted_ntt_size; i++) {
@@ -256,4 +360,14 @@ void runtime::he::he_seal::ckks::multiply_by_double_inplace(
 
   // Set the scale
   encrypted.scale() = new_scale;
+  NGRAPH_INFO << "encrypted scale after mult " << encrypted.scale();
+
+#ifndef SEAL_ALLOW_TRANSPARENT_CIPHERTEXT
+  // Transparent ciphertext output is not allowed.
+  if (encrypted.is_transparent()) {
+    NGRAPH_INFO << "encrypted.uint64_count() " << encrypted.uint64_count();
+    NGRAPH_INFO << "size " << encrypted.size();
+    throw ngraph_error("result ciphertext is transparent");
+  }
+#endif
 }

--- a/src/seal/ckks/seal_ckks_util.cpp
+++ b/src/seal/ckks/seal_ckks_util.cpp
@@ -339,12 +339,6 @@ void runtime::he::he_seal::ckks::multiply_plain_inplace(
     throw ngraph_error("scale out of bounds");
   }
 
-  // Done doing "encoding"
-  NGRAPH_INFO << "Done fake encoding " << value << " at scale " << scale;
-  for (const auto& elem : plaintext_vals) {
-    NGRAPH_INFO << elem;
-  }
-
   for (size_t i = 0; i < encrypted_ntt_size; i++) {
     for (size_t j = 0; j < coeff_mod_count; j++) {
       // Multiply by scalar instead of doing dyadic product

--- a/src/seal/ckks/seal_ckks_util.hpp
+++ b/src/seal/ckks/seal_ckks_util.hpp
@@ -67,18 +67,73 @@ void match_modulus_and_scale_inplace(
     const HESealCKKSBackend* he_seal_ckks_backend,
     seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool());
 
-void multiply_by_double_inplace(
+void encode(double value, double scale, seal::parms_id_type parms_id,
+            std::vector<std::uint64_t>& destination,
+            const HESealCKKSBackend* he_seal_ckks_backend,
+            seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool());
+
+void add_plain_inplace(seal::Ciphertext& encrypted, double value,
+                       const HESealCKKSBackend* he_seal_ckks_backend);
+
+inline void add_plain(const seal::Ciphertext& encrypted, double value,
+                      seal::Ciphertext& destination,
+                      const HESealCKKSBackend* he_seal_ckks_backend) {
+  destination = encrypted;
+  ngraph::runtime::he::he_seal::ckks::add_plain_inplace(destination, value,
+                                                        he_seal_ckks_backend);
+}
+
+// Like add_poly_poly_coeffmod, but with a scalar for operand2
+inline void add_poly_scalar_coeffmod(const std::uint64_t* poly,
+                                     std::size_t coeff_count,
+                                     std::uint64_t scalar,
+                                     const seal::SmallModulus& modulus,
+                                     std::uint64_t* result) {
+  const uint64_t modulus_value = modulus.value();
+  NGRAPH_INFO << "Adding coeff_count " << coeff_count;
+#ifdef SEAL_DEBUG
+  if (poly == nullptr && coeff_count > 0) {
+    throw ngraph_error("poly");
+  }
+  if (scalar >= modulus_value) {
+    throw ngraph_error("scalar");
+  }
+  if (modulus.is_zero()) {
+    throw ngraph_error("modulus");
+  }
+  if (result == nullptr && coeff_count > 0) {
+    throw ngraph_error("result");
+  }
+#endif
+
+  for (; coeff_count--; result++, poly++) {
+    // Explicit inline
+    // result[i] = add_uint_uint_mod(poly[i], scalar, modulus);
+#ifdef SEAL_DEBUG
+    if (*poly >= modulus_value) {
+      throw ngraph_error("poly > modulus_value");
+    }
+
+#endif
+    std::uint64_t sum = *poly + scalar;
+    *result = sum - (modulus_value &
+                     static_cast<std::uint64_t>(
+                         -static_cast<std::int64_t>(sum >= modulus_value)));
+  }
+}
+
+void multiply_plain_inplace(
     seal::Ciphertext& encrypted, double value,
     const HESealCKKSBackend* he_seal_ckks_backend,
     seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool());
 
-inline void multiply_by_double(
+inline void multiply_plain(
     const seal::Ciphertext& encrypted, double value,
     seal::Ciphertext& destination,
     const HESealCKKSBackend* he_seal_ckks_backend,
     seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool()) {
   destination = encrypted;
-  ngraph::runtime::he::he_seal::ckks::multiply_by_double_inplace(
+  ngraph::runtime::he::he_seal::ckks::multiply_plain_inplace(
       destination, value, he_seal_ckks_backend, std::move(pool));
 }
 }  // namespace ckks

--- a/src/seal/ckks/seal_ckks_util.hpp
+++ b/src/seal/ckks/seal_ckks_util.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <iomanip>
 #include <memory>
 #include <utility>
@@ -64,8 +65,22 @@ void match_scale(S* arg0, T* arg1,
 void match_modulus_and_scale_inplace(
     SealCiphertextWrapper* arg0, SealCiphertextWrapper* arg1,
     const HESealCKKSBackend* he_seal_ckks_backend,
-    const seal::MemoryPoolHandle& pool = seal::MemoryManager::GetPool());
+    seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool());
 
+void multiply_by_double_inplace(
+    seal::Ciphertext& encrypted, double value,
+    const HESealCKKSBackend* he_seal_ckks_backend,
+    seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool());
+
+inline void multiply_by_double(
+    const seal::Ciphertext& encrypted, double value,
+    seal::Ciphertext& destination,
+    const HESealCKKSBackend* he_seal_ckks_backend,
+    seal::MemoryPoolHandle pool = seal::MemoryManager::GetPool()) {
+  destination = encrypted;
+  ngraph::runtime::he::he_seal::ckks::multiply_by_double_inplace(
+      destination, value, he_seal_ckks_backend, std::move(pool));
+}
 }  // namespace ckks
 }  // namespace he_seal
 }  // namespace he

--- a/src/seal/ckks/seal_ckks_util.hpp
+++ b/src/seal/ckks/seal_ckks_util.hpp
@@ -90,7 +90,6 @@ inline void add_poly_scalar_coeffmod(const std::uint64_t* poly,
                                      const seal::SmallModulus& modulus,
                                      std::uint64_t* result) {
   const uint64_t modulus_value = modulus.value();
-  NGRAPH_INFO << "Adding coeff_count " << coeff_count;
 #ifdef SEAL_DEBUG
   if (poly == nullptr && coeff_count > 0) {
     throw ngraph_error("poly");

--- a/test/test_dot.in.cpp
+++ b/test/test_dot.in.cpp
@@ -27,30 +27,6 @@ using namespace ngraph;
 
 static string s_manifest = "${MANIFEST}";
 
-NGRAPH_TEST(${BACKEND_NAME}, dot1d_small_cipher_plain) {
-  auto backend = runtime::Backend::create("${BACKEND_NAME}");
-  auto he_backend = static_cast<runtime::he::HEBackend*>(backend.get());
-
-  Shape shape{2};
-  Shape shape_result{};
-  auto a = make_shared<op::Parameter>(element::f32, shape);
-  auto b = make_shared<op::Parameter>(element::f32, shape);
-  auto t = make_shared<op::Dot>(a, b);
-  auto f = make_shared<Function>(t, ParameterVector{a, b});
-
-  auto t_a = he_backend->create_cipher_tensor(element::f32, shape);
-  auto t_b = he_backend->create_plain_tensor(element::f32, shape);
-  auto t_result = he_backend->create_cipher_tensor(element::f32, shape_result);
-
-  copy_data(t_a, vector<float>{7, 8});
-  copy_data(t_b, vector<float>{1, 1});
-
-  auto handle = backend->compile(f);
-  handle->call_with_validate({t_result}, {t_a, t_b});
-  EXPECT_TRUE(
-      all_close(read_vector<float>(t_result), vector<float>{15}, 1e-3f));
-}
-
 NGRAPH_TEST(${BACKEND_NAME}, dot1d) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
 

--- a/test/test_dot.in.cpp
+++ b/test/test_dot.in.cpp
@@ -27,6 +27,30 @@ using namespace ngraph;
 
 static string s_manifest = "${MANIFEST}";
 
+NGRAPH_TEST(${BACKEND_NAME}, dot1d_small_cipher_plain) {
+  auto backend = runtime::Backend::create("${BACKEND_NAME}");
+  auto he_backend = static_cast<runtime::he::HEBackend*>(backend.get());
+
+  Shape shape{2};
+  Shape shape_result{};
+  auto a = make_shared<op::Parameter>(element::f32, shape);
+  auto b = make_shared<op::Parameter>(element::f32, shape);
+  auto t = make_shared<op::Dot>(a, b);
+  auto f = make_shared<Function>(t, ParameterVector{a, b});
+
+  auto t_a = he_backend->create_cipher_tensor(element::f32, shape);
+  auto t_b = he_backend->create_plain_tensor(element::f32, shape);
+  auto t_result = he_backend->create_cipher_tensor(element::f32, shape_result);
+
+  copy_data(t_a, vector<float>{7, 8});
+  copy_data(t_b, vector<float>{1, 1});
+
+  auto handle = backend->compile(f);
+  handle->call_with_validate({t_result}, {t_a, t_b});
+  EXPECT_TRUE(
+      all_close(read_vector<float>(t_result), vector<float>{15}, 1e-3f));
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, dot1d) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
 


### PR DESCRIPTION
* Added multiply_plain / add_plain when add/multiplying by a single floating-point value; this avoids the expensive encoding step
* Single-threaded CryptoNets runtime down to 68s from 82s