### PR TITLE
Fboemer/barrett reduce 64

### DIFF
--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -71,7 +71,6 @@ ngraph::he::HESealBackend::HESealBackend(
   // Encoder
   m_ckks_encoder = std::make_shared<seal::CKKSEncoder>(m_context);
 
-  // Set s_barrett64_ratio_map
   for (const seal::SmallModulus& modulus :
        context_data->parms().coeff_modulus()) {
     const std::uint64_t modulus_value = modulus.value();
@@ -83,8 +82,6 @@ ngraph::he::HESealBackend::HESealBackend(
       std::uint64_t const_ratio = quotient[0];
 
       NGRAPH_CHECK(quotient[1] == 0, "Quotient[1] != 0 for modulus");
-
-      NGRAPH_INFO << "Const ratio" << const_ratio;
       m_barrett64_ratio_map[modulus_value] = const_ratio;
     }
   }

--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -71,6 +71,24 @@ ngraph::he::HESealBackend::HESealBackend(
   // Encoder
   m_ckks_encoder = std::make_shared<seal::CKKSEncoder>(m_context);
 
+  // Set s_barrett64_ratio_map
+  for (const seal::SmallModulus& modulus :
+       context_data->parms().coeff_modulus()) {
+    const std::uint64_t modulus_value = modulus.value();
+    if (modulus_value < (1 << 30)) {
+      std::uint64_t numerator[3]{0, 1};
+      std::uint64_t quotient[3]{0, 0};
+      seal::util::divide_uint128_uint64_inplace(numerator, modulus_value,
+                                                quotient);
+      std::uint64_t const_ratio = quotient[0];
+
+      NGRAPH_CHECK(quotient[1] == 0, "Quotient[1] != 0 for modulus");
+
+      NGRAPH_INFO << "Const ratio" << const_ratio;
+      m_barrett64_ratio_map[modulus_value] = const_ratio;
+    }
+  }
+
   NGRAPH_CHECK(!(m_encrypt_model && m_complex_packing),
                "NGRAPH_ENCRYPT_MODEL is incompatible with NGRAPH_COMPLEX_PACK");
 }

--- a/src/seal/he_seal_backend.hpp
+++ b/src/seal/he_seal_backend.hpp
@@ -181,6 +181,11 @@ class HESealBackend : public ngraph::runtime::Backend {
     return m_encryption_params;
   };
 
+  const std::unordered_map<std::uint64_t, std::uint64_t>& barrett64_ratio_map()
+      const {
+    return m_barrett64_ratio_map;
+  }
+
   void set_batch_data(bool batch) { m_batch_data = batch; };
 
   bool complex_packing() const { return m_complex_packing; }
@@ -208,6 +213,9 @@ class HESealBackend : public ngraph::runtime::Backend {
   std::shared_ptr<seal::CKKSEncoder> m_ckks_encoder;
   // Scale with which to encode new ciphertexts
   double m_scale;
+
+  // Stores Barrett64 ratios for moduli under 30 bits
+  std::unordered_map<std::uint64_t, std::uint64_t> m_barrett64_ratio_map;
 };
 
 }  // namespace he

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -671,7 +671,9 @@ void ngraph::he::HESealExecutable::generate_calls(
 
   // TODO: move to static function
   auto lazy_rescaling = [this](auto& cipher_tensor) {
-  // NGRAPH_INFO << "Lazy rescaling";
+    NGRAPH_INFO << "Lazy rescaling";
+    typedef std::chrono::high_resolution_clock Clock;
+    auto t1 = Clock::now();
 #pragma omp parallel for
     for (size_t i = 0; i < cipher_tensor->get_elements().size(); ++i) {
       auto cipher = cipher_tensor->get_element(i);
@@ -680,6 +682,12 @@ void ngraph::he::HESealExecutable::generate_calls(
             cipher->ciphertext());
       }
     }
+    auto t2 = Clock::now();
+    NGRAPH_INFO << "rescale time "
+                << std::chrono::duration_cast<std::chrono::microseconds>(t2 -
+                                                                         t1)
+                       .count()
+                << " us";
   };
 
   std::vector<Shape> arg_shapes{};

--- a/src/seal/seal_util.cpp
+++ b/src/seal/seal_util.cpp
@@ -295,9 +295,6 @@ void ngraph::he::multiply_plain_inplace(seal::Ciphertext& encrypted,
                                         double value,
                                         const HESealBackend& he_seal_backend,
                                         seal::MemoryPoolHandle pool) {
-  typedef std::chrono::high_resolution_clock Clock;
-  auto t1 = Clock::now();
-
   // Verify parameters.
   auto context = he_seal_backend.get_context();
   if (!encrypted.is_metadata_valid_for(context)) {
@@ -376,17 +373,6 @@ void ngraph::he::multiply_plain_inplace(seal::Ciphertext& encrypted,
     throw ngraph_error("result ciphertext is transparent");
   }
 #endif
-
-  auto t4 = Clock::now();
-
-  /* NGRAPH_INFO
-       << "encode time "
-       << std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2).count()
-       << " us"; */
-  NGRAPH_INFO
-      << "multiply plain time "
-      << std::chrono::duration_cast<std::chrono::microseconds>(t4 - t1).count()
-      << " us";
 }
 
 void ngraph::he::multiply_poly_scalar_coeffmod64(

--- a/src/seal/seal_util.hpp
+++ b/src/seal/seal_util.hpp
@@ -89,6 +89,14 @@ inline void add_plain(const seal::Ciphertext& encrypted, double value,
   ngraph::he::add_plain_inplace(destination, value, he_seal_backend);
 }
 
+// Like seal's multiply_poly_scalar_coeffmod, except assuming scalar, modulus
+// and poly are all < 30 bits
+void multiply_poly_scalar_coeffmod64(const uint64_t* poly, size_t coeff_count,
+                                     uint64_t scalar,
+                                     const std::uint64_t modulus_value,
+                                     const std::uint64_t const_ratio,
+                                     uint64_t* result);
+
 // Like add_poly_poly_coeffmod, but with a scalar for operand2
 inline void add_poly_scalar_coeffmod(const std::uint64_t* poly,
                                      std::size_t coeff_count,

--- a/test/test_multiply.in.cpp
+++ b/test/test_multiply.in.cpp
@@ -233,6 +233,29 @@ NGRAPH_TEST(${BACKEND_NAME}, multiply_2_3_cipher_plain_complex) {
                         read_vector<float>(t_result), 1e-3f));
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, multiply_2_3_cipher_plain) {
+  auto backend = runtime::Backend::create("${BACKEND_NAME}");
+  auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());
+
+  Shape shape{2, 3};
+  auto a = make_shared<op::Parameter>(element::f32, shape);
+  auto b = make_shared<op::Parameter>(element::f32, shape);
+  auto t = make_shared<op::Multiply>(a, b);
+  auto f = make_shared<Function>(t, ParameterVector{a, b});
+
+  // Create some tensors for input/output
+  auto t_a = he_backend->create_cipher_tensor(element::f32, shape);
+  auto t_b = he_backend->create_plain_tensor(element::f32, shape);
+  auto t_result = he_backend->create_cipher_tensor(element::f32, shape);
+
+  copy_data(t_a, vector<float>{-2, -1, 0, 1, 2, 3});
+  copy_data(t_b, vector<float>{3, -2, 5, 3, 2, -5});
+  auto handle = backend->compile(f);
+  handle->call_with_validate({t_result}, {t_a, t_b});
+  EXPECT_TRUE(all_close((vector<float>{-6, 2, 0, 3, 4, -15}),
+                        read_vector<float>(t_result), 1e-3f));
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, multiply_2_3_cipher_cipher_complex) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
   auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());

--- a/test/test_perf.in.cpp
+++ b/test/test_perf.in.cpp
@@ -111,7 +111,7 @@ NGRAPH_TEST(${BACKEND_NAME}, perf_mult_plain) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
   auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());
 
-  size_t N{10};
+  size_t N{10000};
 
   Shape shape{N};
   auto a = make_shared<op::Parameter>(element::f32, shape);

--- a/test/test_perf.in.cpp
+++ b/test/test_perf.in.cpp
@@ -106,3 +106,37 @@ NGRAPH_TEST(${BACKEND_NAME}, perf_square) {
     handle->call_with_validate({t_result}, {t_a, t_b});
   }
 }
+
+NGRAPH_TEST(${BACKEND_NAME}, perf_mult_plain) {
+  auto backend = runtime::Backend::create("${BACKEND_NAME}");
+  auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());
+
+  size_t N{10};
+
+  Shape shape{N};
+  auto a = make_shared<op::Parameter>(element::f32, shape);
+  auto b = make_shared<op::Parameter>(element::f32, shape);
+  auto t = make_shared<op::Multiply>(a, b);
+  auto f = make_shared<Function>(t, ParameterVector{a, b});
+
+  vector<float> vec_a(N, 0);
+  vector<float> vec_b(N, 0);
+  vector<float> vec_result(N, 0);
+
+  for (size_t i = 0; i < N; ++i) {
+    vec_a[i] = (i + 1) % 20 + 1;
+    vec_b[i] = (i + 2) % 20 + 1;
+    vec_result[i] = vec_a[i] * vec_b[i];
+  }
+
+  auto t_a = he_backend->create_cipher_tensor(element::f32, shape);
+  auto t_b = he_backend->create_plain_tensor(element::f32, shape);
+  auto t_result = he_backend->create_cipher_tensor(element::f32, shape);
+
+  copy_data(t_a, vec_a);
+  copy_data(t_b, vec_b);
+
+  auto handle = backend->compile(f);
+  handle->call_with_validate({t_result}, {t_a, t_b});
+  EXPECT_TRUE(all_close(read_vector<float>(t_result), vec_result, 1e-3f));
+}


### PR DESCRIPTION
* Special case for Multiply-plain with barrett64 reduction.
* Multiply_plain goes from 33 microseconds => 13 microseconds.