### PR TITLE
axpy.py => ax.py

### DIFF
--- a/docker/build_and_test_he_transformer.sh
+++ b/docker/build_and_test_he_transformer.sh
@@ -49,8 +49,8 @@ python_integration()
 {
     echo 'Running python examples'
     cd examples
-    python axpy.py
-    NGRAPH_TF_BACKEND=HE_SEAL python axpy.py
+    python ax.py
+    NGRAPH_TF_BACKEND=HE_SEAL python ax.py
     cd MNIST-Cryptonets
     NGRAPH_HE_SEAL_CONFIG=../../test/model/he_seal_ckks_config_N13_L7.json \
         NGRAPH_TF_BACKEND=HE_SEAL \


### PR DESCRIPTION
Initially there was a typo in the file name. It prevents the build from running the tests in the examples/ directory.