### PR TITLE
Fboemer/protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 # Build options python version used in virtual environment
 find_package(PythonInterp 3)
 if(PYTHONINTERP_FOUND)
-  message("PYTHON_VERSION_STRING " ${PYTHON_VERSION_STRING})
+  message(STATUS "PYTHON_VERSION_STRING " ${PYTHON_VERSION_STRING})
 elseif()
   message(FATAL_ERROR "Python3 not found.")
 endif()
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHON_VENV_VERSION)
   set(PYTHON_VENV_VERSION
       "python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 endif()
-message("PYTHON_VENV_VERSION ${PYTHON_VENV_VERSION}")
+message(STATUS "PYTHON_VENV_VERSION ${PYTHON_VENV_VERSION}")
 
 option(NGRAPH_HE_SANITIZE_ADDRESS "Enable address sanitizer" OFF)
 
@@ -101,6 +101,28 @@ if(NGRAPH_HE_SANITIZE_ADDRESS)
       "${CMAKE_CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer")
 endif()
 
+# Get OS version
+if(NOT APPLE)
+  execute_process(COMMAND cat /etc/os-release
+                  OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\""
+                 ""
+                 LSB_RELEASE_ID_SHORT
+                 ${LSB_RELEASE_ID_SHORT})
+  string(REGEX MATCH
+               "ID=\([a-z])+"
+               OS_VERSION
+               "${LSB_RELEASE_ID_SHORT}")
+  string(REGEX MATCH
+               "([a-z])+"
+               OS_VERSION
+               "${OS_VERSION}")
+  message(STATUS "OS version: ${OS_VERSION}")
+else()
+  # Handle the case for MacOS TBD
+endif()
+
 include(cmake/ngraph-tf.cmake)
 include(cmake/gtest.cmake)
 include(cmake/json.cmake)
@@ -108,8 +130,6 @@ include(cmake/openmp.cmake)
 include(cmake/seal.cmake)
 include(cmake/boost.cmake)
 include(cmake/protobuf.cmake)
-
-message("ngraph NGRAPH_TF_INCLUDE_DIR ${NGRAPH_TF_INCLUDE_DIR}")
 
 # Add ngraph library
 add_library(ngraph SHARED IMPORTED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(PROJECT_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 add_definitions(-DPROJECT_ROOT_DIR="${PROJECT_ROOT_DIR}")
 
-# This allows libhe_backend.so to find libraries in the same directory
+# This allows libhe_seal_backend.so to find libraries in the same directory
 set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 
 # he-transformer headers
@@ -135,7 +135,7 @@ include(cmake/protobuf.cmake)
 add_library(ngraph SHARED IMPORTED)
 set_target_properties(ngraph
                       PROPERTIES IMPORTED_LOCATION
-                                 ${NGRAPH_TF_LIB_DIR}/libngraph.so)
+                                 ${EXTERNAL_INSTALL_LIB_DIR}/libngraph.so)
 set_target_properties(ngraph
                       PROPERTIES INCLUDE_DIRECTORIES ${NGRAPH_TF_INCLUDE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,14 +131,6 @@ include(cmake/seal.cmake)
 include(cmake/boost.cmake)
 include(cmake/protobuf.cmake)
 
-# Add ngraph library
-add_library(ngraph SHARED IMPORTED)
-set_target_properties(ngraph
-                      PROPERTIES IMPORTED_LOCATION
-                                 ${EXTERNAL_INSTALL_LIB_DIR}/libngraph.so)
-set_target_properties(ngraph
-                      PROPERTIES INCLUDE_DIRECTORIES ${NGRAPH_TF_INCLUDE_DIR})
-
 # HE transformer source and test directories
 add_subdirectory(src)
 add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The [examples](https://github.com/NervanaSystems/he-transformer/tree/master/exam
 - bazel v0.25.2
 #### The following dependencies are built automatically
 - [nGraph](https://github.com/NervanaSystems/ngraph) - v0.25.0
-- [nGraph-tf](https://github.com/tensorflow/ngraph-bridge) - v0.18.0
+- [nGraph-tf](https://github.com/tensorflow/ngraph-bridge) - v0.18.1
 - [SEAL](https://github.com/Microsoft/SEAL) - v3.3.1
 - [TensorFlow](https://github.com/tensorflow/tensorflow) - v1.14.0
 - Boost 1.69

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The [examples](https://github.com/NervanaSystems/he-transformer/tree/master/exam
 - [nGraph-tf](https://github.com/tensorflow/ngraph-bridge) - v0.18.1
 - [SEAL](https://github.com/Microsoft/SEAL) - v3.3.1
 - [TensorFlow](https://github.com/tensorflow/tensorflow) - v1.14.0
-- Boost 1.69
+- [Boost](https://github.com/boostorg) v1.69
+- [Google protobuf](https://github.com/protocolbuffers/protobuf) v3.9.1
 
 We also offer [docker containers](https://github.com/NervanaSystems/he-transformer/tree/master/contrib/docker) and builds of he-transformer on a reference OS.
 

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -31,6 +31,7 @@ ExternalProject_Add(ext_json
                                   ${JSON_SRC_DIR}/single_include/nlohmann
                                   ${EXTERNAL_INSTALL_DIR}/include/
                     INSTALL_COMMAND ""
+                    UPDATE_COMMAND ""
                     EXCLUDE_FROM_ALL TRUE)
 
 ExternalProject_Get_Property(ext_json SOURCE_DIR)

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -20,7 +20,7 @@ set(EXTERNAL_NGRAPH_INSTALL_DIR ${EXTERNAL_INSTALL_DIR})
 set(NGRAPH_TF_CMAKE_PREFIX ext_ngraph_tf)
 
 set(NGRAPH_TF_REPO_URL https://github.com/tensorflow/ngraph-bridge.git)
-set(NGRAPH_TF_GIT_LABEL fboemer/debug_he_backend)
+set(NGRAPH_TF_GIT_LABEL v0.18.1)
 
 set(NGRAPH_TF_SRC_DIR
     ${CMAKE_BINARY_DIR}/${NGRAPH_TF_CMAKE_PREFIX}/src/${NGRAPH_TF_CMAKE_PREFIX})

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -20,7 +20,7 @@ set(EXTERNAL_NGRAPH_INSTALL_DIR ${EXTERNAL_INSTALL_DIR})
 set(NGRAPH_TF_CMAKE_PREFIX ext_ngraph_tf)
 
 set(NGRAPH_TF_REPO_URL https://github.com/tensorflow/ngraph-bridge.git)
-set(NGRAPH_TF_GIT_LABEL v0.18.0)
+set(NGRAPH_TF_GIT_LABEL fboemer/debug_he_backend)
 
 set(NGRAPH_TF_SRC_DIR
     ${CMAKE_BINARY_DIR}/${NGRAPH_TF_CMAKE_PREFIX}/src/${NGRAPH_TF_CMAKE_PREFIX})
@@ -72,7 +72,8 @@ ExternalProject_Add(ext_ngraph_tf
                                     -fs
                                     ${NGRAPH_TF_VENV_DIR}
                                     ${EXTERNAL_INSTALL_DIR}
-                    UPDATE_COMMAND "")
+                    UPDATE_COMMAND ""
+                    )
 
 ExternalProject_Get_Property(ext_ngraph_tf SOURCE_DIR)
 add_library(libngraph_tf INTERFACE)

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -72,8 +72,7 @@ ExternalProject_Add(ext_ngraph_tf
                                     -fs
                                     ${NGRAPH_TF_VENV_DIR}
                                     ${EXTERNAL_INSTALL_DIR}
-                    UPDATE_COMMAND ""
-                    )
+                    UPDATE_COMMAND "")
 
 ExternalProject_Get_Property(ext_ngraph_tf SOURCE_DIR)
 add_library(libngraph_tf INTERFACE)

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -42,16 +42,13 @@ set(NGRAPH_TF_INCLUDE_DIR ${NGRAPH_TF_ARTIFACTS_DIR}/include)
 
 set(NGRAPH_TEST_UTIL_INCLUDE_DIR ${NGRAPH_TF_BUILD_DIR}/ngraph/test)
 
-message("NGRAPH_TF_VENV_LIB_DIR ${NGRAPH_TF_VENV_LIB_DIR}")
-message("NGRAPH_TF_LIB_DIR ${NGRAPH_TF_LIB_DIR}")
-
 set(ng_tf_build_flags "")
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  message("Using debug build for ng-tf")
+  message(STATUS "Using debug build for ng-tf")
   set(ng_tf_build_flags "--debug_build")
 endif()
 if(${USE_PREBUILT_TF})
-  message("Using prebuilt TF")
+  message(STATUS "Using prebuilt TF")
   set(
     ng_tf_build_flags
 

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -79,7 +79,7 @@ add_dependencies(libngraph_tf ext_ngraph_tf)
 add_library(ngraph SHARED IMPORTED)
 set_target_properties(ngraph
                       PROPERTIES IMPORTED_LOCATION
-                                 ${EXTERNAL_INSTALL_LIB_DIR}/libngraph.so)
+                                 ${NGRAPH_TF_LIB_DIR}/libngraph.so)
 set_target_properties(ngraph
                       PROPERTIES INCLUDE_DIRECTORIES ${NGRAPH_TF_INCLUDE_DIR})
 

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -78,6 +78,14 @@ ExternalProject_Get_Property(ext_ngraph_tf SOURCE_DIR)
 add_library(libngraph_tf INTERFACE)
 add_dependencies(libngraph_tf ext_ngraph_tf)
 
+# Add ngraph library
+add_library(ngraph SHARED IMPORTED)
+set_target_properties(ngraph
+                      PROPERTIES IMPORTED_LOCATION
+                                 ${EXTERNAL_INSTALL_LIB_DIR}/libngraph.so)
+set_target_properties(ngraph
+                      PROPERTIES INCLUDE_DIRECTORIES ${NGRAPH_TF_INCLUDE_DIR})
+
 install(DIRECTORY ${NGRAPH_TF_LIB_DIR}/
         DESTINATION ${EXTERNAL_INSTALL_LIB_DIR}
         FILES_MATCHING

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -29,29 +29,6 @@ set(NGRAPH_TF_ARTIFACTS_DIR ${NGRAPH_TF_BUILD_DIR}/artifacts)
 
 set(NGRAPH_TF_VENV_DIR ${NGRAPH_TF_BUILD_DIR}/venv-tf-py3)
 
-# From ngraph-bridge
-if(NOT APPLE)
-  execute_process(COMMAND cat /etc/os-release
-                  OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-  string(REPLACE "\""
-                 ""
-                 LSB_RELEASE_ID_SHORT
-                 ${LSB_RELEASE_ID_SHORT})
-
-  string(REGEX MATCH
-               "ID=\([a-z])+"
-               OS_VERSION
-               "${LSB_RELEASE_ID_SHORT}")
-  string(REGEX MATCH
-               "([a-z])+"
-               OS_VERSION
-               "${OS_VERSION}")
-  message("OS version is: ${OS_VERSION}")
-else()
-  # Handle the case for MacOS TBD
-endif()
-
 if(OS_VERSION STREQUAL "centos")
   set(NGRAPH_TF_LIB_DIR ${NGRAPH_TF_ARTIFACTS_DIR}/lib64)
 else()

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -23,7 +23,7 @@ set(
   https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protobuf-cpp-3.9.1.tar.gz
   )
 
-message("Extneral install dir ${EXTERNAL_INSTALL_DIR}")
+message(STATUS "Installing protobuf to ${EXTERNAL_INSTALL_DIR}")
 
 ExternalProject_Add(
   ext_protobuf

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -90,6 +90,10 @@ add_custom_target(libprotobuf_soft_link ALL
                   DEPENDS libprotobuf
                   COMMAND ${CMAKE_COMMAND}
                           -E
+                          make_directory
+                          ${NGRAPH_TF_LIB_DIR}
+                  COMMAND ${CMAKE_COMMAND}
+                          -E
                           copy
                           ${EXTERNAL_INSTALL_LIB_DIR}/libprotobuf.so*
                           ${NGRAPH_TF_LIB_DIR})

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -63,8 +63,6 @@ get_filename_component(message_proto
 get_filename_component(message_proto_path "${message_proto}" PATH)
 set(message_proto_srcs ${CMAKE_CURRENT_BINARY_DIR}/protos/message.pb.cc)
 set(message_proto_hdrs ${CMAKE_CURRENT_BINARY_DIR}/protos/message.pb.h)
-message("message_proto_srcs ${message_proto_srcs}")
-message("message_proto ${message_proto}")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/protos)
 

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -46,7 +46,7 @@ message(STATUS "protoc BINARY_DIR ${BINARY_DIR}")
 add_library(libprotobuf_orig SHARED IMPORTED)
 set_target_properties(libprotobuf_orig
                       PROPERTIES IMPORTED_LOCATION
-                                 ${EXTERNAL_INSTALL_DIR}/lib/libprotobuf.so)
+                                 ${EXTERNAL_INSTALL_LIB_DIR}/libprotobuf.so)
 target_include_directories(libprotobuf_orig
                            INTERFACE ${EXTERNAL_INSTALL_DIR}/include)
 add_dependencies(libprotobuf_orig ext_protobuf)

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -86,3 +86,12 @@ add_library(libprotobuf INTERFACE)
 target_include_directories(libprotobuf INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(libprotobuf INTERFACE libprotobuf_orig)
 add_dependencies(libprotobuf libprotobuf_orig protobuf_files)
+
+# Create symbolic links for protobuf to allow pyhe_client to find it
+add_custom_target(libprotobuf_soft_link ALL
+                  DEPENDS libprotobuf
+                  COMMAND ${CMAKE_COMMAND}
+                          -E
+                          copy
+                          ${EXTERNAL_INSTALL_LIB_DIR}/libprotobuf.so*
+                          ${NGRAPH_TF_LIB_DIR})

--- a/cmake/seal.cmake
+++ b/cmake/seal.cmake
@@ -45,7 +45,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
   add_compile_options(-Wno-inconsistent-missing-destructor-override)
   add_compile_options(-Wno-extra-semi)
 endif()
-message("SEAL_CXX_FLAGS ${SEAL_CXX_FLAGS}")
+message(STATUS "SEAL_CXX_FLAGS ${SEAL_CXX_FLAGS}")
 
 ExternalProject_Add(
   ext_seal

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -39,7 +39,7 @@ Most _make_ targets are structured in the form `<action>_<compiler>`.  The `<act
 
 Note that all operations performed inside the docker image are run as a regular user, using the `run-as-user.sh` script.  This is done to avoid writing root-owned files in mounted filesystems.
 
-* Additionally, the `RM_CONTAINER` flag (default is False) may be used to persist the docker containers. By default `RM_CONTAINER=true`, and the docker containers are removed after building. Setting `RM_CONTAINER=false` will keep the containers, enabling an easy way to build he-transformer without installing the required software dependencies.
+* Additionally, the `RM_CONTAINER` flag may be used to persist the docker containers. By default `RM_CONTAINER=true`, and the docker containers are removed after building. Setting `RM_CONTAINER=false` will keep the containers, enabling an easy way to build he-transformer without installing the required software dependencies.
 
 ## Examples/Hints
 

--- a/examples/MNIST/pyclient_mnist.py
+++ b/examples/MNIST/pyclient_mnist.py
@@ -48,10 +48,8 @@ def test_mnist_cnn(FLAGS):
     print('Sleeping until client is done')
     while not client.is_done():
         time.sleep(1)
-    print('client.is._done()?', client.is_done())
 
     results = client.get_results()
-    print('get results', results)
     results = np.round(results, 2)
 
     y_pred_reshape = np.array(results).reshape(batch_size, 10)

--- a/examples/MNIST/pyclient_mnist.py
+++ b/examples/MNIST/pyclient_mnist.py
@@ -48,6 +48,7 @@ def test_mnist_cnn(FLAGS):
     print('Sleeping until client is done')
     while not client.is_done():
         time.sleep(1)
+    print('client.is._done()?', client.is_done())
 
     results = client.get_results()
     results = np.round(results, 2)

--- a/examples/MNIST/pyclient_mnist.py
+++ b/examples/MNIST/pyclient_mnist.py
@@ -51,6 +51,7 @@ def test_mnist_cnn(FLAGS):
     print('client.is._done()?', client.is_done())
 
     results = client.get_results()
+    print('get results', results)
     results = np.round(results, 2)
 
     y_pred_reshape = np.array(results).reshape(batch_size, 10)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -39,8 +39,6 @@ message(STATUS "PYTHON_ARTIFACTS_DIR ${PYTHON_ARTIFACTS_DIR}")
 set(PYTHON_LIB_DIR ${PYTHON_ARTIFACTS_DIR}/lib)
 set(PYTHON_INCLUDE_DIR ${PYTHON_ARTIFACTS_DIR}/include)
 
-message(STATUS "PROJECT_ROOT_DIR ${PROJECT_ROOT_DIR}")
-
 # Hack to install files for python wheel When specifying DESTDIR in custom
 # command, this will change the destination to DESTDIR, rather than
 # EXTERNAL_INSTALL_INCLUDE_DIR

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,22 +24,22 @@ ExternalProject_Add(pybind11
                     INSTALL_COMMAND ""
                     UPDATE_COMMAND "")
 
-message("python CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}")
-message("python CMAKE_BINARY_DIR ${CMAKE_BINARY_DIR}")
-message("python CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "python CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}")
+message(STATUS "python CMAKE_BINARY_DIR ${CMAKE_BINARY_DIR}")
+message(STATUS "python CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
 
 set(BUILD_SH_IN "${CMAKE_SOURCE_DIR}/python/build_wheel.sh.in")
 set(BUILD_SH "${CMAKE_BINARY_DIR}/python/build_wheel.sh")
 configure_file(${BUILD_SH_IN} ${BUILD_SH} @ONLY)
 
-message("EXTERNAL_INSTALL_LIB_DIR ${EXTERNAL_INSTALL_LIB_DIR}")
+message(STATUS "EXTERNAL_INSTALL_LIB_DIR ${EXTERNAL_INSTALL_LIB_DIR}")
 
 set(PYTHON_ARTIFACTS_DIR ${CMAKE_BINARY_DIR}/python/_install)
-message("PYTHON_ARTIFACTS_DIR ${PYTHON_ARTIFACTS_DIR}")
+message(STATUS "PYTHON_ARTIFACTS_DIR ${PYTHON_ARTIFACTS_DIR}")
 set(PYTHON_LIB_DIR ${PYTHON_ARTIFACTS_DIR}/lib)
 set(PYTHON_INCLUDE_DIR ${PYTHON_ARTIFACTS_DIR}/include)
 
-message("PROJECT_ROOT_DIR ${PROJECT_ROOT_DIR}")
+message(STATUS "PROJECT_ROOT_DIR ${PROJECT_ROOT_DIR}")
 
 # Hack to install files for python wheel When specifying DESTDIR in custom
 # command, this will change the destination to DESTDIR, rather than
@@ -48,7 +48,9 @@ install(DIRECTORY ${EXTERNAL_INSTALL_INCLUDE_DIR}/
         DESTINATION ${EXTERNAL_INSTALL_INCLUDE_DIR}
         FILES_MATCHING
         PATTERN "*.hpp"
-        PATTERN "*.h")
+        PATTERN "*.h"
+        PATTERN "*.inc" # For port_def.inc in protobuf
+        )
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/python/dist/
                    POST_BUILD
                    DEPENDS he_seal_backend

--- a/python/setup.py
+++ b/python/setup.py
@@ -116,6 +116,7 @@ include_dirs = [
     PYNGRAPH_ROOT_DIR, NGRAPH_HE_INCLUDE_DIR, PYBIND11_INCLUDE_DIR,
     BOOST_INCLUDE_DIR
 ]
+print('include_dirs', include_dirs)
 
 library_dirs = [NGRAPH_HE_LIB_DIR]
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,15 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         PATTERN "*.hpp"
         PATTERN "*.h")
 
+install(DIRECTORY ${CMAKE_BINARY_DIR}/protos
+        DESTINATION ${EXTERNAL_INSTALL_INCLUDE_DIR}
+        FILES_MATCHING
+        PATTERN "*.hpp"
+        PATTERN "*.h")
+
+message(STATUS "CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "CMAKE_BINARY_DIR ${CMAKE_BINARY_DIR}")
+
 # Create symbolic links for he_seal_backend, to allow ngraph and ngraph-tf to
 # recognize find it.
 add_custom_target(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,3 +109,12 @@ add_custom_target(
     create_symlink
     ${EXTERNAL_INSTALL_LIB_DIR}/libhe_seal_backend${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${NGRAPH_TF_LIB_DIR}/libhe_seal_backend${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+# Create symbolic links for protobuf to allow pyhe_client to find it
+add_custom_target(libprotobuf_soft_link ALL
+                  DEPENDS he_seal_backend
+                  COMMAND ${CMAKE_COMMAND}
+                          -E
+                          copy
+                          ${EXTERNAL_INSTALL_DIR}/lib/libprotobuf.so*
+                          ${NGRAPH_TF_LIB_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,16 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/protos
 message(STATUS "CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "CMAKE_BINARY_DIR ${CMAKE_BINARY_DIR}")
 
+# Create symbolic links for protobuf to allow pyhe_client to find it
+add_custom_target(libprotobuf_soft_link ALL
+                  DEPENDS he_seal_backend
+                  COMMAND ${CMAKE_COMMAND}
+                          -E
+                          copy
+                          ${EXTERNAL_INSTALL_DIR}/lib/libprotobuf.so*
+                          ${NGRAPH_TF_LIB_DIR})
+
+
 # Create symbolic links for he_seal_backend, to allow ngraph and ngraph-tf to
 # recognize find it.
 add_custom_target(
@@ -109,12 +119,3 @@ add_custom_target(
     create_symlink
     ${EXTERNAL_INSTALL_LIB_DIR}/libhe_seal_backend${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${NGRAPH_TF_LIB_DIR}/libhe_seal_backend${CMAKE_SHARED_LIBRARY_SUFFIX})
-
-# Create symbolic links for protobuf to allow pyhe_client to find it
-add_custom_target(libprotobuf_soft_link ALL
-                  DEPENDS he_seal_backend
-                  COMMAND ${CMAKE_COMMAND}
-                          -E
-                          copy
-                          ${EXTERNAL_INSTALL_DIR}/lib/libprotobuf.so*
-                          ${NGRAPH_TF_LIB_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         PATTERN "*.hpp"
         PATTERN "*.h")
 
+# Install protobuf files
 install(DIRECTORY ${CMAKE_BINARY_DIR}/protos
         DESTINATION ${EXTERNAL_INSTALL_INCLUDE_DIR}
         FILES_MATCHING

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,16 +92,6 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/protos
 message(STATUS "CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "CMAKE_BINARY_DIR ${CMAKE_BINARY_DIR}")
 
-# Create symbolic links for protobuf to allow pyhe_client to find it
-add_custom_target(libprotobuf_soft_link ALL
-                  DEPENDS he_seal_backend
-                  COMMAND ${CMAKE_COMMAND}
-                          -E
-                          copy
-                          ${EXTERNAL_INSTALL_DIR}/lib/libprotobuf.so*
-                          ${NGRAPH_TF_LIB_DIR})
-
-
 # Create symbolic links for he_seal_backend, to allow ngraph and ngraph-tf to
 # recognize find it.
 add_custom_target(

--- a/src/protos/message.proto
+++ b/src/protos/message.proto
@@ -34,7 +34,8 @@ message Function {
 }
 
 message SealCiphertextWrapper {
-  bool known_value = 1;
-  float value = 2;
-  bytes ciphertext = 3;
+  bool complex_packing = 1;
+  bool known_value = 2;
+  float value = 3;
+  bytes ciphertext = 4;
 }

--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -47,7 +47,6 @@ ngraph::he::HESealBackend::HESealBackend()
 ngraph::he::HESealBackend::HESealBackend(
     const ngraph::he::HESealEncryptionParameters& parms)
     : m_encryption_params(parms) {
-  NGRAPH_INFO << "Creatign backend from parms";
   seal::sec_level_type sec_level = seal::sec_level_type::none;
   if (parms.security_level() == 128) {
     sec_level = seal::sec_level_type::tc128;

--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -47,6 +47,7 @@ ngraph::he::HESealBackend::HESealBackend()
 ngraph::he::HESealBackend::HESealBackend(
     const ngraph::he::HESealEncryptionParameters& parms)
     : m_encryption_params(parms) {
+  NGRAPH_INFO << "Creatign backend from parms";
   seal::sec_level_type sec_level = seal::sec_level_type::none;
   if (parms.security_level() == 128) {
     sec_level = seal::sec_level_type::tc128;

--- a/src/seal/he_seal_backend.hpp
+++ b/src/seal/he_seal_backend.hpp
@@ -51,6 +51,7 @@ class BackendConstructor;
 }
 namespace he {
 class HESealCipherTensor;
+class SealCiphertextWrapper;
 class HESealBackend : public ngraph::runtime::Backend {
  public:
   HESealBackend();

--- a/src/seal/he_seal_cipher_tensor.cpp
+++ b/src/seal/he_seal_cipher_tensor.cpp
@@ -57,6 +57,7 @@ void ngraph::he::HESealCipherTensor::write(
     bool complex_packing) {
   size_t type_byte_size = element_type.size();
   size_t num_elements_to_write = n / (type_byte_size * batch_size);
+  NGRAPH_INFO << "Writing " << num_elements_to_write << " elements";
 
   NGRAPH_CHECK(destination.size() >= num_elements_to_write,
                "Writing too many ciphertexts ", num_elements_to_write,

--- a/src/seal/he_seal_cipher_tensor.cpp
+++ b/src/seal/he_seal_cipher_tensor.cpp
@@ -102,6 +102,7 @@ void ngraph::he::HESealCipherTensor::write(
               ckks_encoder, encryptor, complex_packing);
     }
   }
+  NGRAPH_INFO << "Done writing " << num_elements_to_write << " elements";
 }
 
 void ngraph::he::HESealCipherTensor::read(void* target, size_t n) const {

--- a/src/seal/he_seal_cipher_tensor.cpp
+++ b/src/seal/he_seal_cipher_tensor.cpp
@@ -57,8 +57,6 @@ void ngraph::he::HESealCipherTensor::write(
     bool complex_packing) {
   size_t type_byte_size = element_type.size();
   size_t num_elements_to_write = n / (type_byte_size * batch_size);
-  NGRAPH_INFO << "Writing " << num_elements_to_write << " elements";
-
   NGRAPH_CHECK(destination.size() >= num_elements_to_write,
                "Writing too many ciphertexts ", num_elements_to_write,
                " to destination size ", destination.size());
@@ -102,7 +100,6 @@ void ngraph::he::HESealCipherTensor::write(
               ckks_encoder, encryptor, complex_packing);
     }
   }
-  NGRAPH_INFO << "Done writing " << num_elements_to_write << " elements";
 }
 
 void ngraph::he::HESealCipherTensor::read(void* target, size_t n) const {

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -348,5 +348,4 @@ void ngraph::he::HESealClient::close_connection() {
   NGRAPH_INFO << "Closing connection";
   m_tcp_client->close();
   m_is_done = true;
-  NGRAPH_INFO << "Setting is done true";
 }

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -175,9 +175,7 @@ void ngraph::he::HESealClient::handle_inference_request(
   he_proto::TCPMessage encrypted_inputs_msg;
   encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
 
-  for (const auto& cipher : ciphers) {
-    cipher->save(*encrypted_inputs_msg.add_ciphers());
-  }
+  ngraph::he::save_to_proto(ciphers, encrypted_inputs_msg);
 
   NGRAPH_INFO << "Creating execute message";
   write_message(encrypted_inputs_msg);

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -257,6 +257,10 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
     he_proto::TCPMessage&& proto_msg) {
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
+  const std::string& function = proto_msg.function().function();
+  json js = json::parse(function);
+  double bound = js.at("bound");
+
   proto_msg.set_type(he_proto::TCPMessage_Type_RESPONSE);
 
   size_t result_count = proto_msg.ciphers_size();
@@ -271,7 +275,7 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
         post_bounded_relu_cipher, proto_msg.ciphers(result_idx), m_context);
 
     ngraph::he::scalar_bounded_relu_seal(
-        *post_bounded_relu_cipher, post_bounded_relu_cipher, 6.0f,
+        *post_bounded_relu_cipher, post_bounded_relu_cipher, bound,
         m_context->first_parms_id(), m_scale, *m_ckks_encoder, *m_encryptor,
         *m_decryptor);
     post_bounded_relu_cipher->save(*proto_msg.mutable_ciphers(result_idx));
@@ -342,8 +346,8 @@ void ngraph::he::HESealClient::handle_message(
       if (proto_msg->has_function()) {
         const std::string& function = proto_msg->function().function();
         json js = json::parse(function);
-
         auto name = js.at("function");
+
         if (name == "Parameter") {
           handle_inference_request(*proto_msg);
         } else if (name == "Relu") {

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -172,8 +172,6 @@ void ngraph::he::HESealClient::handle_inference_request(
       m_context->first_parms_id(), m_scale, *m_ckks_encoder, *m_encryptor,
       complex_packing());
 
-  NGRAPH_INFO << "Saving to proto";
-
   const size_t maximum_message_cnt = 100;
   for (size_t parm_idx = 0; parm_idx < parameter_size;
        parm_idx += maximum_message_cnt) {
@@ -184,14 +182,10 @@ void ngraph::he::HESealClient::handle_inference_request(
     if (parm_idx == end_idx) {
       break;
     }
-    NGRAPH_INFO << "Creating execute message from " << parm_idx << " to "
-                << end_idx;
-
     he_proto::TCPMessage encrypted_inputs_msg;
     encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
     ngraph::he::save_to_proto(ciphers.begin() + parm_idx,
                               ciphers.begin() + end_idx, encrypted_inputs_msg);
-    NGRAPH_INFO << "Writing message";
     write_message(encrypted_inputs_msg);
   }
 }
@@ -199,9 +193,7 @@ void ngraph::he::HESealClient::handle_inference_request(
 void ngraph::he::HESealClient::handle_result(
     const he_proto::TCPMessage& proto_msg) {
   size_t result_count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "handling result count " << result_count;
   m_results.resize(result_count * m_batch_size);
-  NGRAPH_INFO << "m_results size " << m_results.size();
   std::vector<std::shared_ptr<SealCiphertextWrapper>> result_ciphers(
       result_count);
 #pragma omp parallel for

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -199,7 +199,6 @@ void ngraph::he::HESealClient::handle_result(
   for (size_t result_idx = 0; result_idx < result_count; ++result_idx) {
     ngraph::he::SealCiphertextWrapper::load(
         result_ciphers[result_idx], proto_msg.ciphers(result_idx), m_context);
-    result_ciphers[result_idx]->complex_packing() = complex_packing();
   }
 
   size_t num_bytes = result_count * sizeof(double) * m_batch_size;
@@ -233,7 +232,6 @@ void ngraph::he::HESealClient::handle_relu_request(
     auto post_relu_cipher = std::make_shared<SealCiphertextWrapper>();
     ngraph::he::SealCiphertextWrapper::load(
         post_relu_cipher, proto_msg.ciphers(result_idx), m_context);
-    post_relu_cipher->complex_packing() = complex_packing();
 
     ngraph::he::scalar_relu_seal(*post_relu_cipher, post_relu_cipher,
                                  m_context->first_parms_id(), m_scale,
@@ -273,7 +271,6 @@ void ngraph::he::HESealClient::handle_max_pool_request(
   for (size_t cipher_idx = 0; cipher_idx < cipher_count; ++cipher_idx) {
     ngraph::he::SealCiphertextWrapper::load(
         max_pool_ciphers[cipher_idx], proto_msg.ciphers(cipher_idx), m_context);
-    max_pool_ciphers[cipher_idx]->complex_packing() = complex_packing();
   }
 
   // We currently just support max_pool with single output

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -340,7 +340,7 @@ void ngraph::he::HESealClient::handle_message(
     }
     case he_proto::TCPMessage_Type_UNKNOWN:
     default:
-      NGRAPH_CHECK(false, "Unknonwn TCPMesage type");
+      NGRAPH_CHECK(false, "Unknonwn TCPMessage type");
   }
 }
 

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -109,7 +109,7 @@ void ngraph::he::HESealClient::send_public_and_relin_keys() {
   eval_key.set_eval_key(evk_stream.str());
   *proto_msg.mutable_eval_key() = eval_key;
 
-  write_message(proto_msg);
+  write_message(std::move(proto_msg));
 }
 
 void ngraph::he::HESealClient::handle_encryption_parameters_response(
@@ -179,7 +179,7 @@ void ngraph::he::HESealClient::handle_inference_request(
     encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
     ngraph::he::save_to_proto(ciphers.begin() + parm_idx,
                               ciphers.begin() + end_idx, encrypted_inputs_msg);
-    write_message(encrypted_inputs_msg);
+    write_message(std::move(encrypted_inputs_msg));
   }
 }
 
@@ -226,8 +226,8 @@ void ngraph::he::HESealClient::handle_relu_request(
     post_relu_cipher->save(*proto_msg.mutable_ciphers(result_idx));
   }
 
-  ngraph::he::TCPMessage relu_result_msg(proto_msg);
-  write_message(relu_result_msg);
+  ngraph::he::TCPMessage relu_result_msg(std::move(proto_msg));
+  write_message(std::move(relu_result_msg));
   return;
 }
 
@@ -259,8 +259,8 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
     post_bounded_relu_cipher->save(*proto_msg.mutable_ciphers(result_idx));
   }
 
-  ngraph::he::TCPMessage bounded_relu_result_msg(proto_msg);
-  write_message(bounded_relu_result_msg);
+  ngraph::he::TCPMessage bounded_relu_result_msg(std::move(proto_msg));
+  write_message(std::move(bounded_relu_result_msg));
   return;
 }
 
@@ -294,9 +294,8 @@ void ngraph::he::HESealClient::handle_max_pool_request(
   *proto_max_pool.mutable_function() = proto_msg.function();
 
   post_max_pool_ciphers[0]->save(*proto_max_pool.add_ciphers());
-  ngraph::he::TCPMessage max_pool_result_msg(proto_max_pool);
-
-  write_message(max_pool_result_msg);
+  ngraph::he::TCPMessage max_pool_result_msg(std::move(proto_max_pool));
+  write_message(std::move(max_pool_result_msg));
   return;
 }
 

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -165,10 +165,6 @@ void ngraph::he::HESealClient::handle_inference_request(
     ciphers[data_idx] = std::make_shared<SealCiphertextWrapper>();
   }
 
-  for (const auto& elem : m_inputs) {
-    NGRAPH_INFO << "input " << elem;
-  }
-
   // TODO: add element type to function message
   size_t num_bytes = parameter_size * sizeof(double);
   ngraph::he::HESealCipherTensor::write(

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -266,7 +266,6 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
 
 void ngraph::he::HESealClient::handle_max_pool_request(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "Handling max_pool request";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
   size_t cipher_count = proto_msg.ciphers_size();

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -171,9 +171,6 @@ void ngraph::he::HESealClient::handle_inference_request(
       m_context->first_parms_id(), m_scale, *m_ckks_encoder, *m_encryptor,
       complex_packing());
 
-  he_proto::TCPMessage encrypted_inputs_msg;
-  encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
-
   NGRAPH_INFO << "Saving to proto";
 
   const size_t maximum_message_cnt = 100;
@@ -189,10 +186,11 @@ void ngraph::he::HESealClient::handle_inference_request(
     NGRAPH_INFO << "Creating execute message from " << parm_idx << " to "
                 << end_idx;
 
+    he_proto::TCPMessage encrypted_inputs_msg;
+    encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
     ngraph::he::save_to_proto(ciphers.begin() + parm_idx,
                               ciphers.begin() + end_idx, encrypted_inputs_msg);
     NGRAPH_INFO << "Writing message";
-
     write_message(encrypted_inputs_msg);
   }
 }

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -307,7 +307,6 @@ void ngraph::he::HESealClient::handle_message(
 
   switch (proto_msg->type()) {
     case he_proto::TCPMessage_Type_RESPONSE: {
-      NGRAPH_INFO << "Client got message RESPONSE";
       if (proto_msg->has_encryption_parameters()) {
         handle_encryption_parameters_response(*proto_msg);
       } else if (proto_msg->ciphers_size() > 0) {

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -180,13 +180,7 @@ void ngraph::he::HESealClient::handle_inference_request(
   encrypted_inputs_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
 
   for (size_t data_idx = 0; data_idx < ciphers.size(); ++data_idx) {
-    he_proto::SealCiphertextWrapper* proto_cipher =
-        encrypted_inputs_msg.add_ciphers();
-    proto_cipher->set_known_value(false);
-    // TODO: save directly to protobuf
-    std::stringstream s;
-    ciphers[data_idx]->ciphertext().save(s);
-    proto_cipher->set_ciphertext(s.str());
+    ciphers[data_idx]->save(*encrypted_inputs_msg.add_ciphers());
   }
 
   NGRAPH_INFO << "Creating execute message";
@@ -271,12 +265,7 @@ void ngraph::he::HESealClient::handle_relu_request(
                                  m_context->first_parms_id(), m_scale,
                                  *m_ckks_encoder, *m_encryptor, *m_decryptor);
 
-    he_proto::SealCiphertextWrapper* proto_cipher = proto_relu.add_ciphers();
-    proto_cipher->set_known_value(false);
-    // TODO: save directly to protobuf
-    std::stringstream s;
-    post_relu_cipher->ciphertext().save(s);
-    proto_cipher->set_ciphertext(s.str());
+    post_relu_cipher->save(*proto_relu.add_ciphers());
   }
 
   ngraph::he::TCPMessage relu_result_msg(proto_relu);

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -233,7 +233,6 @@ void ngraph::he::HESealClient::handle_relu_request(
 
 void ngraph::he::HESealClient::handle_bounded_relu_request(
     he_proto::TCPMessage&& proto_msg) {
-  NGRAPH_INFO << "handling bounded relu rqst";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
   const std::string& function = proto_msg.function().function();
@@ -260,7 +259,6 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
     post_bounded_relu_cipher->save(*proto_msg.mutable_ciphers(result_idx));
   }
 
-  NGRAPH_INFO << "done handling bounded relu rqst";
   ngraph::he::TCPMessage bounded_relu_result_msg(std::move(proto_msg));
   write_message(std::move(bounded_relu_result_msg));
   return;
@@ -309,6 +307,7 @@ void ngraph::he::HESealClient::handle_message(
 
   switch (proto_msg->type()) {
     case he_proto::TCPMessage_Type_RESPONSE: {
+      NGRAPH_INFO << "Client got message RESPONSE";
       if (proto_msg->has_encryption_parameters()) {
         handle_encryption_parameters_response(*proto_msg);
       } else if (proto_msg->ciphers_size() > 0) {

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -330,8 +330,6 @@ void ngraph::he::HESealClient::handle_message(
       break;
     }
     case he_proto::TCPMessage_Type_REQUEST: {
-      NGRAPH_INFO << "Client got message REQUEST";
-
       if (proto_msg->has_function()) {
         const std::string& function = proto_msg->function().function();
         json js = json::parse(function);

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -201,6 +201,10 @@ void ngraph::he::HESealClient::handle_result(
       complex_packing());
 
   NGRAPH_INFO << "done handling result";
+  for (const auto& elem : m_results) {
+    NGRAPH_INFO << elem;
+  }
+  NGRAPH_INFO << "Done print resl";
 
   close_connection();
 }
@@ -350,4 +354,5 @@ void ngraph::he::HESealClient::close_connection() {
   NGRAPH_INFO << "Closing connection";
   m_tcp_client->close();
   m_is_done = true;
+  NGRAPH_INFO << "Setting is done true";
 }

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -233,6 +233,7 @@ void ngraph::he::HESealClient::handle_relu_request(
 
 void ngraph::he::HESealClient::handle_bounded_relu_request(
     he_proto::TCPMessage&& proto_msg) {
+  NGRAPH_INFO << "handling bounded relu rqst";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
   const std::string& function = proto_msg.function().function();
@@ -259,6 +260,7 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
     post_bounded_relu_cipher->save(*proto_msg.mutable_ciphers(result_idx));
   }
 
+  NGRAPH_INFO << "done handling bounded relu rqst";
   ngraph::he::TCPMessage bounded_relu_result_msg(std::move(proto_msg));
   write_message(std::move(bounded_relu_result_msg));
   return;
@@ -307,7 +309,6 @@ void ngraph::he::HESealClient::handle_message(
 
   switch (proto_msg->type()) {
     case he_proto::TCPMessage_Type_RESPONSE: {
-      NGRAPH_INFO << "Client got message RESPONSE";
       if (proto_msg->has_encryption_parameters()) {
         handle_encryption_parameters_response(*proto_msg);
       } else if (proto_msg->ciphers_size() > 0) {

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -207,13 +207,6 @@ void ngraph::he::HESealClient::handle_result(
       m_results.data(), result_ciphers, num_bytes, m_batch_size, element::f64,
       m_context->first_parms_id(), m_scale, *m_ckks_encoder, *m_decryptor,
       complex_packing());
-
-  NGRAPH_INFO << "done handling result";
-  for (const auto& elem : m_results) {
-    NGRAPH_INFO << elem;
-  }
-  NGRAPH_INFO << "Done print resl";
-
   close_connection();
 }
 

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -165,7 +165,7 @@ void ngraph::he::HESealClient::handle_inference_request(
   }
 
   // TODO: add element type to function message
-  size_t num_bytes = parameter_size * sizeof(double);
+  size_t num_bytes = parameter_size * sizeof(double) * m_batch_size;
   ngraph::he::HESealCipherTensor::write(
       ciphers, m_inputs.data(), num_bytes, m_batch_size, element::f64,
       m_context->first_parms_id(), m_scale, *m_ckks_encoder, *m_encryptor,

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -144,7 +144,8 @@ void ngraph::he::HESealClient::handle_inference_request(
 
   NGRAPH_INFO << join(shape, "x");
 
-  size_t parameter_size = ngraph::shape_size(shape);
+  size_t parameter_size =
+      ngraph::shape_size(ngraph::he::HETensor::pack_shape(shape));
 
   NGRAPH_INFO << "Parameter size " << parameter_size;
   NGRAPH_INFO << "Client batch size " << m_batch_size;

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -92,8 +92,6 @@ void ngraph::he::HESealClient::set_seal_context() {
 }
 
 void ngraph::he::HESealClient::send_public_and_relin_keys() {
-  NGRAPH_INFO << "SEnding public and relin keys";
-
   he_proto::TCPMessage proto_msg;
   proto_msg.set_type(he_proto::TCPMessage_Type_RESPONSE);
 
@@ -111,13 +109,11 @@ void ngraph::he::HESealClient::send_public_and_relin_keys() {
   eval_key.set_eval_key(evk_stream.str());
   *proto_msg.mutable_eval_key() = eval_key;
 
-  NGRAPH_INFO << "Sending pk / evk";
   write_message(proto_msg);
 }
 
 void ngraph::he::HESealClient::handle_encryption_parameters_response(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "Got enc parms request";
   NGRAPH_CHECK(proto_msg.has_encryption_parameters(),
                "proto_msg does not have encryption_parameters");
 
@@ -126,15 +122,12 @@ void ngraph::he::HESealClient::handle_encryption_parameters_response(
   std::stringstream param_stream(enc_parms_str);
   m_encryption_params = seal::EncryptionParameters::Load(param_stream);
 
-  NGRAPH_INFO << "Loaded enc parms";
-
   set_seal_context();
   send_public_and_relin_keys();
 }
 
 void ngraph::he::HESealClient::handle_inference_request(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "handle_inference_request";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto msg doesn't have funtion");
 
   const std::string& inference_shape = proto_msg.function().function();
@@ -267,7 +260,6 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
   }
 
   ngraph::he::TCPMessage bounded_relu_result_msg(proto_msg);
-  NGRAPH_INFO << "Writing bounded relu result";
   write_message(bounded_relu_result_msg);
   return;
 }
@@ -304,7 +296,6 @@ void ngraph::he::HESealClient::handle_max_pool_request(
   post_max_pool_ciphers[0]->save(*proto_max_pool.add_ciphers());
   ngraph::he::TCPMessage max_pool_result_msg(proto_max_pool);
 
-  NGRAPH_INFO << "Writing max_pool result";
   write_message(max_pool_result_msg);
   return;
 }

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -159,8 +159,7 @@ void ngraph::he::HESealClient::handle_inference_request(
                 << ") * m_batch_size (" << m_batch_size << ")";
   }
 
-  std::vector<std::shared_ptr<SealCiphertextWrapper>> ciphers(parameter_size /
-                                                              m_batch_size);
+  std::vector<std::shared_ptr<SealCiphertextWrapper>> ciphers(parameter_size);
   for (size_t data_idx = 0; data_idx < ciphers.size(); ++data_idx) {
     ciphers[data_idx] = std::make_shared<SealCiphertextWrapper>();
   }
@@ -183,10 +182,10 @@ void ngraph::he::HESealClient::handle_inference_request(
 
 void ngraph::he::HESealClient::handle_result(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "handling result";
-
   size_t result_count = proto_msg.ciphers_size();
+  NGRAPH_INFO << "handling result count " << result_count;
   m_results.resize(result_count * m_batch_size);
+  NGRAPH_INFO << "m_results size " << m_results.size();
   std::vector<std::shared_ptr<SealCiphertextWrapper>> result_ciphers(
       result_count);
 #pragma omp parallel for

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -210,7 +210,6 @@ void ngraph::he::HESealClient::handle_result(
 
 void ngraph::he::HESealClient::handle_relu_request(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "Handling relu request";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
   he_proto::TCPMessage proto_relu;
@@ -218,7 +217,6 @@ void ngraph::he::HESealClient::handle_relu_request(
   *proto_relu.mutable_function() = proto_msg.function();
 
   size_t result_count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "result_count " << result_count;
 
   // TODO: parallelize
   for (size_t result_idx = 0; result_idx < result_count; ++result_idx) {
@@ -237,14 +235,12 @@ void ngraph::he::HESealClient::handle_relu_request(
 
   ngraph::he::TCPMessage relu_result_msg(proto_relu);
 
-  NGRAPH_INFO << "Writing relu result";
   write_message(relu_result_msg);
   return;
 }
 
 void ngraph::he::HESealClient::handle_bounded_relu_request(
     const he_proto::TCPMessage& proto_msg) {
-  NGRAPH_INFO << "Handling bounded_relu request";
   NGRAPH_CHECK(proto_msg.has_function(), "Proto message doesn't have function");
 
   he_proto::TCPMessage proto_relu;
@@ -252,7 +248,6 @@ void ngraph::he::HESealClient::handle_bounded_relu_request(
   *proto_relu.mutable_function() = proto_msg.function();
 
   size_t result_count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "result_count " << result_count;
 
   // TODO: parallelize
   for (size_t result_idx = 0; result_idx < result_count; ++result_idx) {

--- a/src/seal/he_seal_client.hpp
+++ b/src/seal/he_seal_client.hpp
@@ -70,7 +70,10 @@ class HESealClient {
 
   inline bool is_done() { return m_is_done; }
 
-  std::vector<double> get_results() { return m_results; }
+  std::vector<double> get_results() {
+    NGRAPH_INFO << "Getting result size " << m_results.size();
+    return m_results;
+  }
 
   void close_connection();
 

--- a/src/seal/he_seal_client.hpp
+++ b/src/seal/he_seal_client.hpp
@@ -50,9 +50,9 @@ class HESealClient {
 
   void handle_relu_request(const ngraph::he::TCPMessage& message);
 
-  void handle_relu_request(const he_proto::TCPMessage& message);
+  void handle_relu_request(he_proto::TCPMessage&& message);
   void handle_max_pool_request(const he_proto::TCPMessage& message);
-  void handle_bounded_relu_request(const he_proto::TCPMessage& message);
+  void handle_bounded_relu_request(he_proto::TCPMessage&& message);
 
   void handle_result(const he_proto::TCPMessage& message);
 

--- a/src/seal/he_seal_client.hpp
+++ b/src/seal/he_seal_client.hpp
@@ -60,10 +60,6 @@ class HESealClient {
 
   void send_public_and_relin_keys();
 
-  inline void write_message(const ngraph::he::TCPMessage& message) {
-    m_tcp_client->write_message(message);
-  }
-
   inline void write_message(const ngraph::he::TCPMessage&& message) {
     m_tcp_client->write_message(std::move(message));
   }

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -817,8 +817,6 @@ void ngraph::he::HESealExecutable::generate_calls(
   auto out0_cipher = std::dynamic_pointer_cast<HESealCipherTensor>(out[0]);
   auto out0_plain = std::dynamic_pointer_cast<HEPlainTensor>(out[0]);
 
-  NGRAPH_INFO << "Generating calls";
-
   // TODO: move to static function
   auto lazy_rescaling = [this](auto& cipher_tensor,
                                bool verbose_rescaling = true) {

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -327,7 +327,6 @@ void ngraph::he::HESealExecutable::handle_relu_result(
     std::shared_ptr<ngraph::he::SealCiphertextWrapper> new_cipher;
     ngraph::he::SealCiphertextWrapper::load(
         new_cipher, proto_msg.ciphers(element_idx), m_context);
-    new_cipher->complex_packing() = m_complex_packing;
 
     m_relu_ciphertexts[m_unknown_relu_idx[element_idx + m_relu_done_count]] =
         new_cipher;
@@ -348,7 +347,6 @@ void ngraph::he::HESealExecutable::handle_max_pool_result(
   std::shared_ptr<ngraph::he::SealCiphertextWrapper> new_cipher;
   ngraph::he::SealCiphertextWrapper::load(new_cipher, proto_msg.ciphers(0),
                                           m_context);
-  new_cipher->complex_packing() = m_complex_packing;
 
   m_max_pool_ciphertexts.emplace_back(new_cipher);
   m_max_pool_done = true;
@@ -416,7 +414,6 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
   for (size_t cipher_idx = 0; cipher_idx < count; ++cipher_idx) {
     ngraph::he::SealCiphertextWrapper::load(
         he_cipher_inputs[cipher_idx], proto_msg.ciphers(cipher_idx), m_context);
-    he_cipher_inputs[cipher_idx]->complex_packing() = m_complex_packing;
   }
 
   // only support parameter size 1 for now

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -1693,7 +1693,7 @@ void ngraph::he::HESealExecutable::handle_server_max_pool_op(
     he_proto::TCPMessage proto_msg;
     proto_msg.set_type(he_proto::TCPMessage_Type_REQUEST);
 
-    NGRAPH_INFO << "List in " << list_ind;
+    NGRAPH_INFO << "List ind " << list_ind;
 
     json js;
     js["function"] = node.description();

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -752,9 +752,7 @@ void ngraph::he::HESealExecutable::send_client_results() {
                "Client outputs are not HESealCipherTensor");
 
   for (const auto& ciphertext_wrapper : output_cipher_tensor->get_elements()) {
-    he_proto::SealCiphertextWrapper* proto_cipher_wrapper =
-        proto_msg.add_ciphers();
-    ciphertext_wrapper->save(*proto_cipher_wrapper);
+    ciphertext_wrapper->save(*proto_msg.add_ciphers());
   }
 
   NGRAPH_INFO << "Writing Result message with " << proto_msg.ciphers_size()
@@ -1710,9 +1708,7 @@ void ngraph::he::HESealExecutable::handle_server_max_pool_op(
     *proto_msg.mutable_function() = f;
 
     for (const size_t max_ind : maximize_list[list_ind]) {
-      NGRAPH_INFO << "Max ind " << max_ind;
-      he_proto::SealCiphertextWrapper* proto_cipher = proto_msg.add_ciphers();
-      arg0_cipher->get_element(max_ind)->save(*proto_cipher);
+      arg0_cipher->get_element(max_ind)->save(*proto_msg.add_ciphers());
     }
 
     // Send list of ciphertexts to maximize over to client
@@ -1804,12 +1800,8 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
         f.set_function(js.dump());
         *proto_msg.mutable_function() = f;
 
-        for (size_t cipher_idx = 0; cipher_idx < cipher_batch.size();
-             ++cipher_idx) {
-          he_proto::SealCiphertextWrapper* proto_cipher =
-              proto_msg.add_ciphers();
-
-          cipher_batch[cipher_idx]->save(*proto_cipher);
+        for (const auto& cipher : cipher_batch) {
+          cipher->save(*proto_msg.add_ciphers());
         }
 
         ngraph::he::TCPMessage relu_message(proto_msg);

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -434,8 +434,6 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
                get_results().size(), "");
 
   size_t count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "Loading " << count << " ciphertexts";
-
   std::vector<std::shared_ptr<ngraph::he::SealCiphertextWrapper>>
       he_cipher_inputs(count);
 #pragma omp parallel for
@@ -443,8 +441,6 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
     ngraph::he::SealCiphertextWrapper::load(
         he_cipher_inputs[cipher_idx], proto_msg.ciphers(cipher_idx), m_context);
   }
-  NGRAPH_INFO << "Done loading cipher";
-
   const ParameterVector& input_parameters = get_parameters();
 
   // Write ciphers to client inputs

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -1806,8 +1806,15 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
         f.set_function(js.dump());
         *proto_msg.mutable_function() = f;
 
-        for (const auto& cipher : cipher_batch) {
-          cipher->save(*proto_msg.add_ciphers());
+        for (size_t cipher_idx = 0; cipher_idx < cipher_batch.size();
+             ++cipher_idx) {
+          proto_msg.add_ciphers();
+        }
+#pragma omp parallel for
+        for (size_t cipher_idx = 0; cipher_idx < cipher_batch.size();
+             ++cipher_idx) {
+          cipher_batch[cipher_idx]->save(
+              *proto_msg.mutable_ciphers(cipher_idx));
         }
 
         ngraph::he::TCPMessage relu_message(proto_msg);

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -221,7 +221,8 @@ void ngraph::he::HESealExecutable::client_setup() {
       m_client_load_idx.clear();
       const ParameterVector& input_parameters = get_parameters();
       for (auto input_param : input_parameters) {
-        NGRAPH_INFO << "param shape " << join(input_param->get_shape(), "x");
+        NGRAPH_INFO << "parameter shape "
+                    << join(input_param->get_shape(), "x");
         auto element_type = input_param->get_element_type();
 
         auto input_tensor =
@@ -354,7 +355,6 @@ void ngraph::he::HESealExecutable::handle_max_pool_result(
     const he_proto::TCPMessage& proto_msg) {
   std::lock_guard<std::mutex> guard(m_max_pool_mutex);
   size_t message_count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "handle_max_pool_result with count " << message_count;
 
   NGRAPH_CHECK(message_count == 1,
                "Maxpool only supports message count 1, got ", message_count);
@@ -1682,7 +1682,6 @@ void ngraph::he::HESealExecutable::handle_server_max_pool_op(
 
     json js;
     js["function"] = node.description();
-    NGRAPH_INFO << "Description " << js["function"];
 
     he_proto::Function f;
     f.set_function(js.dump());

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -417,7 +417,7 @@ void ngraph::he::HESealExecutable::handle_message(
     }
     case he_proto::TCPMessage_Type_UNKNOWN:
     default:
-      NGRAPH_CHECK(false, "Unknonwn TCPMesage type");
+      NGRAPH_CHECK(false, "Unknonwn TCPMessage type");
   }
 }
 

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -663,7 +663,6 @@ bool ngraph::he::HESealExecutable::call(
     m_timer_map[op].start();
 
     // get op inputs from map
-    NGRAPH_INFO << "Getting op inputs from map";
     std::vector<std::shared_ptr<ngraph::he::HETensor>> op_inputs;
     for (auto input : op->inputs()) {
       descriptor::Tensor* tensor = &input.get_tensor();
@@ -677,7 +676,6 @@ bool ngraph::he::HESealExecutable::call(
     }
 
     // get op outputs from map or create
-    NGRAPH_INFO << "Getting op outputs from map";
     std::vector<std::shared_ptr<ngraph::he::HETensor>> op_outputs;
     for (size_t i = 0; i < op->get_output_size(); ++i) {
       auto tensor = &op->output(i).get_tensor();
@@ -732,7 +730,6 @@ bool ngraph::he::HESealExecutable::call(
       base_type = op->get_inputs().at(0).get_tensor().get_element_type();
     }
 
-    NGRAPH_INFO << "Getting op calls";
     generate_calls(base_type, wrapped, op_outputs, op_inputs);
     m_timer_map[op].stop();
 
@@ -930,7 +927,6 @@ void ngraph::he::HESealExecutable::generate_calls(
     NGRAPH_CHECK(!(arg1_cipher != nullptr && arg1_plain != nullptr),
                  "arg1 is both cipher and plain?");
   }
-  NGRAPH_INFO << "Inputs are ok";
 
   if (verbose) {
     std::stringstream ss;

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -457,7 +457,7 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
     size_t param_size = shape_size(shape) / m_batch_size;
     auto element_type = input_param->get_element_type();
 
-    auto client_input_tensor = dynamic_cast<ngraph::he::HESealCipherTensor&>(
+    auto& client_input_tensor = dynamic_cast<ngraph::he::HESealCipherTensor&>(
         *m_client_inputs[parm_idx]);
 
     NGRAPH_INFO << "Current param size "

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -320,7 +320,6 @@ void ngraph::he::HESealExecutable::handle_relu_result(
     const he_proto::TCPMessage& proto_msg) {
   std::lock_guard<std::mutex> guard(m_relu_mutex);
   size_t message_count = proto_msg.ciphers_size();
-  NGRAPH_INFO << "handle_relu_result with count " << message_count;
 
 #pragma omp parallel for
   for (size_t element_idx = 0; element_idx < message_count; ++element_idx) {

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -481,8 +481,6 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
                  "Client inputs size ", m_client_inputs.size(), "; expected ",
                  get_parameters().size());
 
-    NGRAPH_INFO << "Notifiyng client inputs received";
-
     std::lock_guard<std::mutex> guard(m_client_inputs_mutex);
     m_client_inputs_received = true;
     m_client_inputs_cond.notify_all();
@@ -525,11 +523,7 @@ bool ngraph::he::HESealExecutable::call(
     std::unique_lock<std::mutex> mlock(m_client_inputs_mutex);
     m_client_inputs_cond.wait(
         mlock, std::bind(&HESealExecutable::client_inputs_received, this));
-    NGRAPH_INFO << "client_inputs_received";
-
-    NGRAPH_INFO << "m_client_inputs " << m_client_inputs.size();
-    NGRAPH_INFO << "server_inputs " << server_inputs.size();
-
+    NGRAPH_INFO << "Client inputs_received";
     NGRAPH_CHECK(m_client_inputs.size() == server_inputs.size(),
                  "Recieved incorrect number of inputs from client (got ",
                  m_client_inputs.size(), ", expectd ", server_inputs.size());

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -1795,7 +1795,6 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
 
         json js;
         js["function"] = node.description();
-        NGRAPH_INFO << "Description " << js["function"];
 
         he_proto::Function f;
         f.set_function(js.dump());

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -1766,7 +1766,7 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
   }
 
   // TODO: tune
-  const size_t max_relu_message_cnt = 10000;
+  const size_t max_relu_message_cnt = 100;
 
   m_unknown_relu_idx.clear();
   m_unknown_relu_idx.reserve(element_count);

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -327,6 +327,8 @@ void ngraph::he::HESealExecutable::handle_relu_result(
     ngraph::he::SealCiphertextWrapper::load(
         new_cipher, proto_msg.ciphers(element_idx), m_context);
 
+    // TODO: free proto_message cipher.
+
     m_relu_ciphertexts[m_unknown_relu_idx[element_idx + m_relu_done_count]] =
         new_cipher;
   }

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -362,7 +362,6 @@ void ngraph::he::HESealExecutable::handle_message(
 
   switch (proto_msg->type()) {
     case he_proto::TCPMessage_Type_RESPONSE: {
-      NGRAPH_INFO << "Server got new message RESPONSE";
       if (proto_msg->has_public_key()) {
         load_public_key(*proto_msg);
       }
@@ -392,9 +391,7 @@ void ngraph::he::HESealExecutable::handle_message(
       break;
     }
     case he_proto::TCPMessage_Type_REQUEST: {
-      NGRAPH_INFO << "Server got new message REQUEST";
       if (proto_msg->ciphers_size() > 0) {
-        NGRAPH_INFO << "Got input ciphers";
         handle_client_ciphers(*proto_msg);
       }
       break;

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -350,15 +350,10 @@ void ngraph::he::HESealExecutable::handle_max_pool_result(
   NGRAPH_CHECK(message_count == 1,
                "Maxpool only supports message count 1, got ", message_count);
 
-  seal::Ciphertext cipher;
-  // TODO: load from string directly
-  const std::string& cipher_str = proto_msg.ciphers(0).ciphertext();
-  std::stringstream ss;
-  ss.str(cipher_str);
-  cipher.load(m_context, ss);
-
-  auto new_cipher = std::make_shared<ngraph::he::SealCiphertextWrapper>(
-      cipher, m_complex_packing);
+  std::shared_ptr<ngraph::he::SealCiphertextWrapper> new_cipher;
+  ngraph::he::SealCiphertextWrapper::load(new_cipher, proto_msg.ciphers(0),
+                                          m_context);
+  new_cipher->complex_packing() = m_complex_packing;
 
   m_max_pool_ciphertexts.emplace_back(new_cipher);
   m_max_pool_done = true;

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -1396,17 +1396,10 @@ void ngraph::he::HESealExecutable::generate_calls(
                               out0_plain->get_elements(), output_size);
         break;
       }
-      NGRAPH_INFO << "arg0_cipher == nullptr? " << (arg0_cipher == nullptr);
-      NGRAPH_INFO << "out0_cipher == nullptr? " << (out0_cipher == nullptr);
 
       if (arg0_cipher == nullptr || out0_cipher == nullptr) {
         throw ngraph_error("Relu types not supported");
       }
-      NGRAPH_INFO << "arg0_cipher->num_ciphertexts "
-                  << arg0_cipher->num_ciphertexts();
-      size_t output_size = arg0_cipher->get_batched_element_count();
-      NGRAPH_INFO << "output_size" << output_size;
-
       if (!m_enable_client) {
         NGRAPH_WARN
             << "Performing Relu without client is not privacy-preserving";
@@ -1422,7 +1415,6 @@ void ngraph::he::HESealExecutable::generate_calls(
                               m_he_seal_backend);
         break;
       }
-
       handle_server_relu_op(arg0_cipher, out0_cipher, node_wrapper);
       break;
     }

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -446,6 +446,7 @@ void ngraph::he::HESealExecutable::handle_client_ciphers(
     ngraph::he::SealCiphertextWrapper::load(
         he_cipher_inputs[cipher_idx], proto_msg.ciphers(cipher_idx), m_context);
   }
+  NGRAPH_INFO << "Done loading cipher";
 
   const ParameterVector& input_parameters = get_parameters();
 

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -207,7 +207,7 @@ void ngraph::he::HESealExecutable::client_setup() {
     *proto_msg.mutable_encryption_parameters() = proto_parms;
     proto_msg.set_type(he_proto::TCPMessage_Type_RESPONSE);
 
-    ngraph::he::TCPMessage parms_message(proto_msg);
+    ngraph::he::TCPMessage parms_message(std::move(proto_msg));
     std::unique_lock<std::mutex> mlock(m_session_mutex);
     m_session_cond.wait(mlock,
                         std::bind(&HESealExecutable::session_started, this));
@@ -329,7 +329,7 @@ void ngraph::he::HESealExecutable::send_inference_shape() {
 
   NGRAPH_INFO << "Sending inference shape " << js.dump();
 
-  ngraph::he::TCPMessage execute_msg(proto_msg);
+  ngraph::he::TCPMessage execute_msg(std::move(proto_msg));
   m_session->write_message(std::move(execute_msg));
 }
 
@@ -773,8 +773,7 @@ void ngraph::he::HESealExecutable::send_client_results() {
   NGRAPH_INFO << "Writing Result message with " << proto_msg.ciphers_size()
               << " ciphertexts ";
 
-  ngraph::he::TCPMessage result_msg(proto_msg);
-
+  ngraph::he::TCPMessage result_msg(std::move(proto_msg));
   m_session->write_message(std::move(result_msg));
 
   std::unique_lock<std::mutex> mlock(m_result_mutex);
@@ -1737,7 +1736,7 @@ void ngraph::he::HESealExecutable::handle_server_max_pool_op(
                   << " Maxpool ciphertexts to client";
     }
 
-    ngraph::he::TCPMessage max_pool_message(proto_msg);
+    ngraph::he::TCPMessage max_pool_message(std::move(proto_msg));
     m_session->write_message(std::move(max_pool_message));
 
     // Acquire lock
@@ -1786,7 +1785,7 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
   }
 
   // TODO: tune
-  const size_t max_relu_message_cnt = 100;
+  const size_t max_relu_message_cnt = 1000;
 
   m_unknown_relu_idx.clear();
   m_unknown_relu_idx.reserve(element_count);
@@ -1835,7 +1834,7 @@ void ngraph::he::HESealExecutable::handle_server_relu_op(
 
         ngraph::he::save_to_proto(cipher_batch, proto_msg);
 
-        ngraph::he::TCPMessage relu_message(proto_msg);
+        ngraph::he::TCPMessage relu_message(std::move(proto_msg));
         m_session->write_message(std::move(relu_message));
       };
 

--- a/src/seal/he_seal_executable.hpp
+++ b/src/seal/he_seal_executable.hpp
@@ -153,6 +153,7 @@ class HESealExecutable : public runtime::Executable {
 
   // (Encrypted) inputs to compiled function
   std::vector<std::shared_ptr<ngraph::he::HETensor>> m_client_inputs;
+  std::vector<size_t> m_client_load_idx;
   // (Encrypted) outputs of compiled function
   std::vector<std::shared_ptr<ngraph::he::HETensor>> m_client_outputs;
 

--- a/src/seal/he_seal_executable.hpp
+++ b/src/seal/he_seal_executable.hpp
@@ -89,6 +89,7 @@ class HESealExecutable : public runtime::Executable {
 
   void handle_client_ciphers(const he_proto::TCPMessage& proto_msg);
   void handle_relu_result(const he_proto::TCPMessage& proto_msg);
+  void handle_bounded_relu_result(const he_proto::TCPMessage& proto_msg);
   void handle_max_pool_result(const he_proto::TCPMessage& proto_msg);
 
   void send_client_results();

--- a/src/seal/he_seal_executable.hpp
+++ b/src/seal/he_seal_executable.hpp
@@ -73,7 +73,7 @@ class HESealExecutable : public runtime::Executable {
 
   size_t get_port() const { return m_port; }
 
-  // TODO: merge _done() methods
+  // TODO: merge_done() methods
   bool max_pool_done() const { return m_max_pool_done; }
   bool minimum_done() const { return m_minimum_done; }
 

--- a/src/seal/kernel/bounded_relu_seal.hpp
+++ b/src/seal/kernel/bounded_relu_seal.hpp
@@ -68,7 +68,6 @@ inline void scalar_bounded_relu_seal(
     const seal::parms_id_type& parms_id, double scale,
     seal::CKKSEncoder& ckks_encoder, seal::Encryptor& encryptor,
     seal::Decryptor& decryptor) {
-  NGRAPH_INFO << "Bounded relu with bound " << alpha;
   auto bounded_relu = [alpha](double d) {
     return d > alpha ? alpha : (d > 0) ? d : 0.;
   };

--- a/src/seal/kernel/bounded_relu_seal.hpp
+++ b/src/seal/kernel/bounded_relu_seal.hpp
@@ -54,8 +54,8 @@ inline void bounded_relu_seal(const std::vector<HEPlaintext>& arg,
 inline void scalar_bounded_relu_seal_known_value(
     const SealCiphertextWrapper& arg,
     std::shared_ptr<SealCiphertextWrapper>& out, float alpha) {
-  auto bounded_relu = [alpha](double f) {
-    return f > alpha ? alpha : (f > 0) ? f : 0.f;
+  auto bounded_relu = [alpha](double d) {
+    return d > alpha ? alpha : (d > 0) ? d : 0.;
   };
   NGRAPH_CHECK(arg.known_value());
   out->known_value() = true;
@@ -68,8 +68,9 @@ inline void scalar_bounded_relu_seal(
     const seal::parms_id_type& parms_id, double scale,
     seal::CKKSEncoder& ckks_encoder, seal::Encryptor& encryptor,
     seal::Decryptor& decryptor) {
-  auto bounded_relu = [alpha](double f) {
-    return f > alpha ? alpha : (f > 0) ? f : 0.f;
+  NGRAPH_INFO << "Bounded relu with bound " << alpha;
+  auto bounded_relu = [alpha](double d) {
+    return d > alpha ? alpha : (d > 0) ? d : 0.;
   };
 
   if (arg.known_value()) {

--- a/src/seal/kernel/convolution_seal.hpp
+++ b/src/seal/kernel/convolution_seal.hpp
@@ -65,7 +65,6 @@ inline void convolution_seal(
     NGRAPH_INFO << "Convolution output size " << out_transform_size;
   }
 
-// TODO: don't create new thread for every loop index, only one per thread
 #pragma omp parallel for
   for (size_t out_coord_idx = 0; out_coord_idx < out_transform_size;
        ++out_coord_idx) {
@@ -266,7 +265,6 @@ inline void convolution_seal(
     NGRAPH_INFO << "Convolution output size " << out_transform_size;
   }
 
-// TODO: don't create new thread for every loop index, only one per thread
 #pragma omp parallel for
   for (size_t out_coord_idx = 0; out_coord_idx < out_transform_size;
        ++out_coord_idx) {
@@ -417,7 +415,6 @@ inline void convolution_seal(
     NGRAPH_INFO << "Convolution output size " << out_transform_size;
   }
 
-// TODO: don't create new thread for every loop index, only one per thread
 #pragma omp parallel for
   for (size_t out_coord_idx = 0; out_coord_idx < out_transform_size;
        ++out_coord_idx) {

--- a/src/seal/kernel/dot_seal.hpp
+++ b/src/seal/kernel/dot_seal.hpp
@@ -272,7 +272,6 @@ inline void dot_seal(
       scalar_multiply_seal(mult_arg0, *mult_arg1, prod, element_type,
                            he_seal_backend, pool);
       if (first_add) {
-        // TODO: std::move(prod)?
         sum = prod;
         first_add = false;
       } else {
@@ -402,7 +401,6 @@ inline void dot_seal(
       scalar_multiply_seal(*mult_arg0, mult_arg1, prod, element_type,
                            he_seal_backend, pool);
       if (first_add) {
-        // TODO: std::move(prod)?
         sum = prod;
         first_add = false;
       } else {

--- a/src/seal/kernel/relu_seal.hpp
+++ b/src/seal/kernel/relu_seal.hpp
@@ -46,7 +46,6 @@ inline void relu_seal(const std::vector<HEPlaintext>& arg,
 inline void scalar_relu_seal_known_value(
     const SealCiphertextWrapper& arg,
     std::shared_ptr<SealCiphertextWrapper>& out) {
-  NGRAPH_INFO << "Known valued relu";
   auto relu = [](double d) { return d > 0 ? d : 0.; };
   NGRAPH_CHECK(arg.known_value());
   out->known_value() = true;
@@ -65,14 +64,11 @@ inline void scalar_relu_seal(const SealCiphertextWrapper& arg,
     scalar_relu_seal_known_value(arg, out);
   } else {
     HEPlaintext plain;
-    NGRAPH_INFO << "Decryping";
     ngraph::he::decrypt(plain, arg, decryptor, ckks_encoder);
     const std::vector<double>& arg_vals = plain.values();
     std::vector<double> out_vals(plain.num_values());
     std::transform(arg_vals.begin(), arg_vals.end(), out_vals.begin(), relu);
     plain.set_values(out_vals);
-
-    NGRAPH_INFO << "Encrypting";
     ngraph::he::encrypt(out, plain, parms_id, ngraph::element::f32, scale,
                         ckks_encoder, encryptor, arg.complex_packing());
   }
@@ -93,7 +89,6 @@ inline void relu_seal(
     const HESealBackend& he_seal_backend) {
 #pragma omp parallel for
   for (size_t i = 0; i < count; ++i) {
-    NGRAPH_INFO << "Relu seal ind " << i;
     scalar_relu_seal(*arg[i], out[i], he_seal_backend);
   }
 }

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -115,9 +115,8 @@ inline void load(seal::Ciphertext& cipher,
               new_cipher.uint64_count() * sizeof(std::uint64_t));
   cipher = std::move(new_cipher);
 
-  if (!seal::is_valid_for(cipher, context)) {
-    throw std::invalid_argument("ciphertext data is invalid");
-  }
+  NGRAPH_CHECK(seal::is_valid_for(cipher, context),
+               "ciphertext data is invalid");
 }
 
 class SealCiphertextWrapper {

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -199,5 +199,17 @@ class SealCiphertextWrapper {
   float m_value;
 };
 
+inline void save_to_proto(
+    const std::vector<std::shared_ptr<SealCiphertextWrapper>>& ciphers,
+    he_proto::TCPMessage& proto_msg) {
+  for (size_t cipher_idx = 0; cipher_idx < ciphers.size(); ++cipher_idx) {
+    proto_msg.add_ciphers();
+  }
+#pragma omp parallel for
+  for (size_t cipher_idx = 0; cipher_idx < ciphers.size(); ++cipher_idx) {
+    ciphers[cipher_idx]->save(*proto_msg.mutable_ciphers(cipher_idx));
+  }
+}
+
 }  // namespace he
 }  // namespace ngraph

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -153,11 +153,11 @@ class SealCiphertextWrapper {
   bool& complex_packing() { return m_complex_packing; }
 
   inline void save(he_proto::SealCiphertextWrapper& proto_cipher) {
+    proto_cipher.set_complex_packing(complex_packing());
     proto_cipher.set_known_value(known_value());
     if (known_value()) {
       proto_cipher.set_value(value());
     }
-    proto_cipher.set_complex_packing(complex_packing());
 
     // TODO: save directly to protobuf
     size_t stream_size = ngraph::he::ciphertext_size(m_ciphertext);
@@ -171,7 +171,6 @@ class SealCiphertextWrapper {
                           const he_proto::SealCiphertextWrapper& src,
                           std::shared_ptr<seal::SEALContext> context) {
     dst.complex_packing() = src.complex_packing();
-
     if (src.known_value()) {
       dst.known_value() = true;
       dst.value() = src.value();

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -20,9 +20,106 @@
 
 #include "protos/message.pb.h"
 #include "seal/seal.h"
+#include "seal/seal_util.hpp"
 
 namespace ngraph {
 namespace he {
+inline size_t ciphertext_size(const seal::Ciphertext& cipher) {
+  // TODO: figure out why the extra 8 bytes
+  size_t expected_size = 8;
+  expected_size += sizeof(seal::parms_id_type);
+  expected_size += sizeof(seal::SEAL_BYTE);
+  // size64, poly_modulus_degere, coeff_mod_count
+  expected_size += 3 * sizeof(uint64_t);
+  // scale
+  expected_size += sizeof(double);
+  // data
+  expected_size += 8 * cipher.uint64_count();
+  return expected_size;
+}
+
+inline void save(const seal::Ciphertext& cipher, void* destination) {
+  {
+    static constexpr std::array<size_t, 6> offsets = {
+        sizeof(seal::parms_id_type),
+        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
+        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+            sizeof(uint64_t),
+        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+            2 * sizeof(uint64_t),
+        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+            3 * sizeof(uint64_t),
+        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+            3 * sizeof(uint64_t) + sizeof(double),
+    };
+
+    bool is_ntt_form = cipher.is_ntt_form();
+    uint64_t size = cipher.size();
+    uint64_t polynomial_modulus_degree = cipher.poly_modulus_degree();
+    uint64_t coeff_mod_count = cipher.coeff_mod_count();
+
+    char* dst_char = static_cast<char*>(destination);
+    std::memcpy(destination, (void*)&cipher.parms_id(),
+                sizeof(seal::parms_id_type));
+    std::memcpy(static_cast<void*>(dst_char + offsets[0]), (void*)&is_ntt_form,
+                sizeof(seal::SEAL_BYTE));
+    std::memcpy(static_cast<void*>(dst_char + offsets[1]), (void*)&size,
+                sizeof(uint64_t));
+    std::memcpy(static_cast<void*>(dst_char + offsets[2]),
+                (void*)&polynomial_modulus_degree, sizeof(uint64_t));
+    std::memcpy(static_cast<void*>(dst_char + offsets[3]),
+                (void*)&coeff_mod_count, sizeof(uint64_t));
+    std::memcpy(static_cast<void*>(dst_char + offsets[4]),
+                (void*)&cipher.scale(), sizeof(double));
+    std::memcpy(static_cast<void*>(dst_char + offsets[5]), (void*)cipher.data(),
+                8 * cipher.uint64_count());
+  }
+}
+
+inline void load(seal::Ciphertext& cipher,
+                 std::shared_ptr<seal::SEALContext> context, void* src) {
+  seal::SEAL_BYTE is_ntt_form_byte;
+  uint64_t size64 = 0;
+  seal::parms_id_type parms_id{};
+
+  static constexpr std::array<size_t, 6> offsets = {
+      sizeof(seal::parms_id_type),
+      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
+      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) + sizeof(uint64_t),
+      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+          2 * sizeof(uint64_t),
+      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+          3 * sizeof(uint64_t),
+      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
+          3 * sizeof(uint64_t) + sizeof(double),
+  };
+
+  char* char_src = static_cast<char*>(src);
+  std::memcpy(&parms_id, src, sizeof(seal::parms_id_type));
+
+  seal::Ciphertext new_cipher(context, parms_id);
+
+  std::memcpy(&is_ntt_form_byte, static_cast<void*>(char_src + offsets[0]),
+              sizeof(seal::SEAL_BYTE));
+  std::memcpy(&size64, static_cast<void*>(char_src + offsets[1]),
+              sizeof(uint64_t));
+  std::memcpy(&new_cipher.scale(), static_cast<void*>(char_src + offsets[4]),
+              sizeof(double));
+  bool ntt_form = (is_ntt_form_byte == seal::SEAL_BYTE(0)) ? false : true;
+
+  new_cipher.resize(context, parms_id, size64);
+
+  new_cipher.is_ntt_form() = ntt_form;
+  void* data_src = static_cast<void*>(char_src + offsets[5]);
+  std::memcpy(&new_cipher[0], data_src,
+              new_cipher.uint64_count() * sizeof(std::uint64_t));
+  cipher = std::move(new_cipher);
+
+  if (!seal::is_valid_for(cipher, context)) {
+    throw std::invalid_argument("ciphertext data is invalid");
+  }
+}
+
 class SealCiphertextWrapper {
  public:
   SealCiphertextWrapper() : m_complex_packing(false), m_known_value(false) {}
@@ -65,7 +162,19 @@ class SealCiphertextWrapper {
     // TODO: save directly to protobuf
     std::stringstream s;
     m_ciphertext.save(s);
-    proto_cipher.set_ciphertext(s.str());
+
+    size_t stream_size = ngraph::he::ciphertext_size(m_ciphertext);
+
+    std::string cipher_str;
+    cipher_str.reserve(stream_size);
+    ngraph::he::save(m_ciphertext, cipher_str.data());
+
+    NGRAPH_INFO << "Stream size " << stream_size;
+
+    // proto_cipher.set_ciphertext(std::move(s.str()));
+
+    proto_cipher.set_ciphertext(std::move(cipher_str));
+    NGRAPH_INFO << "save ok";
   }
 
   static inline void load(ngraph::he::SealCiphertextWrapper& dst,
@@ -99,20 +208,6 @@ class SealCiphertextWrapper {
   bool m_known_value;
   float m_value;
 };
-
-inline size_t ciphertext_size(const seal::Ciphertext& cipher) {
-  // TODO: figure out why the extra 8 bytes
-  size_t expected_size = 8;
-  expected_size += sizeof(seal::parms_id_type);
-  expected_size += sizeof(seal::SEAL_BYTE);
-  // size64, poly_modulus_degere, coeff_mod_count
-  expected_size += 3 * sizeof(uint64_t);
-  // scale
-  expected_size += sizeof(double);
-  // data
-  expected_size += 8 * cipher.uint64_count();
-  return expected_size;
-}
 
 }  // namespace he
 }  // namespace ngraph

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -201,6 +201,7 @@ class SealCiphertextWrapper {
 inline void save_to_proto(
     const std::vector<std::shared_ptr<SealCiphertextWrapper>>& ciphers,
     he_proto::TCPMessage& proto_msg) {
+  proto_msg.mutable_ciphers()->Reserve(ciphers.size());
   for (size_t cipher_idx = 0; cipher_idx < ciphers.size(); ++cipher_idx) {
     proto_msg.add_ciphers();
   }

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "protos/message.pb.h"
 #include "seal/seal.h"
 
 namespace ngraph {
@@ -53,6 +54,18 @@ class SealCiphertextWrapper {
 
   bool complex_packing() const { return m_complex_packing; }
   bool& complex_packing() { return m_complex_packing; }
+
+  inline void save(he_proto::SealCiphertextWrapper& proto_cipher) {
+    proto_cipher.set_known_value(known_value());
+    if (known_value()) {
+      proto_cipher.set_value(value());
+    }
+
+    // TODO: save directly to protobuf
+    std::stringstream s;
+    m_ciphertext.save(s);
+    proto_cipher.set_ciphertext(s.str());
+  }
 
  private:
   seal::Ciphertext m_ciphertext;

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -160,21 +160,11 @@ class SealCiphertextWrapper {
     proto_cipher.set_complex_packing(complex_packing());
 
     // TODO: save directly to protobuf
-    std::stringstream s;
-    m_ciphertext.save(s);
-
     size_t stream_size = ngraph::he::ciphertext_size(m_ciphertext);
-
     std::string cipher_str;
-    cipher_str.reserve(stream_size);
+    cipher_str.resize(stream_size);
     ngraph::he::save(m_ciphertext, cipher_str.data());
-
-    NGRAPH_INFO << "Stream size " << stream_size;
-
-    // proto_cipher.set_ciphertext(std::move(s.str()));
-
     proto_cipher.set_ciphertext(std::move(cipher_str));
-    NGRAPH_INFO << "save ok";
   }
 
   static inline void load(ngraph::he::SealCiphertextWrapper& dst,
@@ -188,9 +178,9 @@ class SealCiphertextWrapper {
     } else {
       // TODO: load from string directly
       const std::string& cipher_str = src.ciphertext();
-      std::stringstream ss;
-      ss.str(cipher_str);
-      dst.ciphertext().load(context, ss);
+      ngraph::he::load(
+          dst.ciphertext(), context,
+          static_cast<void*>(const_cast<char*>(cipher_str.data())));
     }
   }
 

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -67,6 +67,24 @@ class SealCiphertextWrapper {
     proto_cipher.set_ciphertext(s.str());
   }
 
+  static inline void load(
+      std::shared_ptr<ngraph::he::SealCiphertextWrapper>& dst,
+      const he_proto::SealCiphertextWrapper& src,
+      std::shared_ptr<seal::SEALContext> context) {
+    dst = std::make_shared<ngraph::he::SealCiphertextWrapper>();
+
+    if (src.known_value()) {
+      dst->known_value() = true;
+      dst->value() = src.value();
+    } else {
+      // TODO: load from string directly
+      const std::string& cipher_str = src.ciphertext();
+      std::stringstream ss;
+      ss.str(cipher_str);
+      dst->ciphertext().load(context, ss);
+    }
+  }
+
  private:
   seal::Ciphertext m_ciphertext;
   bool m_complex_packing;

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -68,23 +68,29 @@ class SealCiphertextWrapper {
     proto_cipher.set_ciphertext(s.str());
   }
 
-  static inline void load(
-      std::shared_ptr<ngraph::he::SealCiphertextWrapper>& dst,
-      const he_proto::SealCiphertextWrapper& src,
-      std::shared_ptr<seal::SEALContext> context) {
-    dst = std::make_shared<ngraph::he::SealCiphertextWrapper>();
-    dst->complex_packing() = src.complex_packing();
+  static inline void load(ngraph::he::SealCiphertextWrapper& dst,
+                          const he_proto::SealCiphertextWrapper& src,
+                          std::shared_ptr<seal::SEALContext> context) {
+    dst.complex_packing() = src.complex_packing();
 
     if (src.known_value()) {
-      dst->known_value() = true;
-      dst->value() = src.value();
+      dst.known_value() = true;
+      dst.value() = src.value();
     } else {
       // TODO: load from string directly
       const std::string& cipher_str = src.ciphertext();
       std::stringstream ss;
       ss.str(cipher_str);
-      dst->ciphertext().load(context, ss);
+      dst.ciphertext().load(context, ss);
     }
+  }
+
+  static inline void load(
+      std::shared_ptr<ngraph::he::SealCiphertextWrapper>& dst,
+      const he_proto::SealCiphertextWrapper& src,
+      std::shared_ptr<seal::SEALContext> context) {
+    dst = std::make_shared<ngraph::he::SealCiphertextWrapper>();
+    load(*dst, src, context);
   }
 
  private:

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -60,6 +60,7 @@ class SealCiphertextWrapper {
     if (known_value()) {
       proto_cipher.set_value(value());
     }
+    proto_cipher.set_complex_packing(complex_packing());
 
     // TODO: save directly to protobuf
     std::stringstream s;
@@ -72,6 +73,7 @@ class SealCiphertextWrapper {
       const he_proto::SealCiphertextWrapper& src,
       std::shared_ptr<seal::SEALContext> context) {
     dst = std::make_shared<ngraph::he::SealCiphertextWrapper>();
+    dst->complex_packing() = src.complex_packing();
 
     if (src.known_value()) {
       dst->known_value() = true;

--- a/src/seal/seal_util.cpp
+++ b/src/seal/seal_util.cpp
@@ -51,6 +51,20 @@ void ngraph::he::print_seal_context(const seal::SEALContext& context) {
   std::cout << "\\" << std::endl;
 }
 
+size_t ngraph::he::get_chain_index(const SealCiphertextWrapper& cipher,
+                                   const HESealBackend& he_seal_backend) {
+  return he_seal_backend.get_context()
+      ->get_context_data(cipher.ciphertext().parms_id())
+      ->chain_index();
+}
+
+size_t ngraph::he::get_chain_index(const SealPlaintextWrapper& plain,
+                                   const HESealBackend& he_seal_backend) {
+  return he_seal_backend.get_context()
+      ->get_context_data(plain.plaintext().parms_id())
+      ->chain_index();
+}
+
 // Matches the modulus chain for the two elements in-place
 // The elements are modified if necessary
 void ngraph::he::match_modulus_and_scale_inplace(
@@ -86,7 +100,7 @@ void ngraph::he::match_modulus_and_scale_inplace(
     chain_ind0 = ngraph::he::get_chain_index(arg0, he_seal_backend);
   }
   NGRAPH_CHECK(chain_ind0 == chain_ind1);
-  ngraph::he::match_scale(arg0, arg1, he_seal_backend);
+  ngraph::he::match_scale(arg0, arg1);
 }
 
 void ngraph::he::add_plain_inplace(seal::Ciphertext& encrypted, double value,
@@ -572,86 +586,4 @@ void ngraph::he::decrypt(ngraph::he::HEPlaintext& output,
   auto plaintext_wrapper = SealPlaintextWrapper(complex_packing);
   decryptor.decrypt(input, plaintext_wrapper.plaintext());
   decode(output, plaintext_wrapper, ckks_encoder);
-}
-
-void ngraph::he::save(const seal::Ciphertext& cipher, void* destination) {
-  {
-    static constexpr std::array<size_t, 6> offsets = {
-        sizeof(seal::parms_id_type),
-        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
-        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-            sizeof(uint64_t),
-        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-            2 * sizeof(uint64_t),
-        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-            3 * sizeof(uint64_t),
-        sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-            3 * sizeof(uint64_t) + sizeof(double),
-    };
-
-    bool is_ntt_form = cipher.is_ntt_form();
-    uint64_t size = cipher.size();
-    uint64_t polynomial_modulus_degree = cipher.poly_modulus_degree();
-    uint64_t coeff_mod_count = cipher.coeff_mod_count();
-
-    char* dst_char = static_cast<char*>(destination);
-    std::memcpy(destination, (void*)&cipher.parms_id(),
-                sizeof(seal::parms_id_type));
-    std::memcpy(static_cast<void*>(dst_char + offsets[0]), (void*)&is_ntt_form,
-                sizeof(seal::SEAL_BYTE));
-    std::memcpy(static_cast<void*>(dst_char + offsets[1]), (void*)&size,
-                sizeof(uint64_t));
-    std::memcpy(static_cast<void*>(dst_char + offsets[2]),
-                (void*)&polynomial_modulus_degree, sizeof(uint64_t));
-    std::memcpy(static_cast<void*>(dst_char + offsets[3]),
-                (void*)&coeff_mod_count, sizeof(uint64_t));
-    std::memcpy(static_cast<void*>(dst_char + offsets[4]),
-                (void*)&cipher.scale(), sizeof(double));
-    std::memcpy(static_cast<void*>(dst_char + offsets[5]), (void*)cipher.data(),
-                8 * cipher.uint64_count());
-  }
-}
-
-void ngraph::he::load(seal::Ciphertext& cipher,
-                      std::shared_ptr<seal::SEALContext> context, void* src) {
-  seal::SEAL_BYTE is_ntt_form_byte;
-  uint64_t size64 = 0;
-  seal::parms_id_type parms_id{};
-
-  static constexpr std::array<size_t, 6> offsets = {
-      sizeof(seal::parms_id_type),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) + sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          2 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t) + sizeof(double),
-  };
-
-  char* char_src = static_cast<char*>(src);
-  std::memcpy(&parms_id, src, sizeof(seal::parms_id_type));
-
-  seal::Ciphertext new_cipher(context, parms_id);
-
-  std::memcpy(&is_ntt_form_byte, static_cast<void*>(char_src + offsets[0]),
-              sizeof(seal::SEAL_BYTE));
-  std::memcpy(&size64, static_cast<void*>(char_src + offsets[1]),
-              sizeof(uint64_t));
-  std::memcpy(&new_cipher.scale(), static_cast<void*>(char_src + offsets[4]),
-              sizeof(double));
-  bool ntt_form = (is_ntt_form_byte == seal::SEAL_BYTE(0)) ? false : true;
-
-  new_cipher.resize(context, parms_id, size64);
-
-  new_cipher.is_ntt_form() = ntt_form;
-  void* data_src = static_cast<void*>(char_src + offsets[5]);
-  std::memcpy(&new_cipher[0], data_src,
-              new_cipher.uint64_count() * sizeof(std::uint64_t));
-  cipher = std::move(new_cipher);
-
-  if (!seal::is_valid_for(cipher, context)) {
-    throw std::invalid_argument("ciphertext data is invalid");
-  }
 }

--- a/src/seal/seal_util.cpp
+++ b/src/seal/seal_util.cpp
@@ -268,7 +268,8 @@ size_t ngraph::he::match_to_smallest_chain_index(
       }
     }
   }
-  NGRAPH_CHECK(smallest_chain_ind.second != std::numeric_limits<size_t>::max());
+  NGRAPH_CHECK(smallest_chain_ind.second != std::numeric_limits<size_t>::max(),
+               "Can't match to modulus of all known values");
   NGRAPH_DEBUG << "Matching to smallest chain index "
                << smallest_chain_ind.second;
 

--- a/src/seal/seal_util.hpp
+++ b/src/seal/seal_util.hpp
@@ -192,6 +192,5 @@ void decrypt(ngraph::he::HEPlaintext& output, const seal::Ciphertext& input,
              bool complex_packing, seal::Decryptor& decryptor,
              seal::CKKSEncoder& ckks_encoder);
 
-
 }  // namespace he
 }  // namespace ngraph

--- a/src/seal/seal_util.hpp
+++ b/src/seal/seal_util.hpp
@@ -28,6 +28,10 @@
 
 namespace ngraph {
 namespace he {
+class SealCiphertextWrapper;
+class SealPlaintextWrapper;
+class HESealBackend;
+
 void print_seal_context(const seal::SEALContext& context);
 
 inline double choose_scale(
@@ -42,19 +46,11 @@ inline double choose_scale(
   }
 }
 
-inline size_t get_chain_index(const SealCiphertextWrapper& cipher,
-                              const HESealBackend& he_seal_backend) {
-  return he_seal_backend.get_context()
-      ->get_context_data(cipher.ciphertext().parms_id())
-      ->chain_index();
-}
+size_t get_chain_index(const SealCiphertextWrapper& cipher,
+                       const HESealBackend& he_seal_backend);
 
-inline size_t get_chain_index(const SealPlaintextWrapper& plain,
-                              const HESealBackend& he_seal_backend) {
-  return he_seal_backend.get_context()
-      ->get_context_data(plain.plaintext().parms_id())
-      ->chain_index();
-}
+size_t get_chain_index(const SealPlaintextWrapper& plain,
+                       const HESealBackend& he_seal_backend);
 
 // Returns the smallest chain index
 size_t match_to_smallest_chain_index(
@@ -73,8 +69,7 @@ inline bool within_rescale_tolerance(const S& arg0, const T& arg1,
 }
 
 template <typename S, typename T>
-inline void match_scale(S& arg0, T& arg1,
-                        const HESealBackend& he_seal_backend) {
+inline void match_scale(S& arg0, T& arg1) {
   auto scale0 = arg0.scale();
   auto scale1 = arg1.scale();
   bool scale_ok = within_rescale_tolerance(arg0, arg1);
@@ -197,10 +192,6 @@ void decrypt(ngraph::he::HEPlaintext& output, const seal::Ciphertext& input,
              bool complex_packing, seal::Decryptor& decryptor,
              seal::CKKSEncoder& ckks_encoder);
 
-void save(const seal::Ciphertext& cipher, void* destination);
-
-void load(seal::Ciphertext& cipher, std::shared_ptr<seal::SEALContext> context,
-          void* src);
 
 }  // namespace he
 }  // namespace ngraph

--- a/src/seal/seal_util.hpp
+++ b/src/seal/seal_util.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include <cmath>
 #include <complex>
 #include <string>

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -118,8 +118,7 @@ class TCPClient {
             do_read_body(msg_len);
 
           } else {
-            // End of file is expected on teardown
-            if (ec.message() != "End of file") {
+            if (ec.message() != s_expected_teardown_message.c_str()) {
               NGRAPH_INFO << "Client error reading header: " << ec.message();
             }
           }
@@ -128,7 +127,6 @@ class TCPClient {
 
   void do_read_body(size_t body_length = 0) {
     NGRAPH_INFO << "Client reading body size " << body_length;
-
     m_read_buffer.resize(header_length + body_length);
 
     boost::asio::async_read(
@@ -141,8 +139,7 @@ class TCPClient {
             m_message_callback(m_read_message);
             do_read_header();
           } else {
-            // End of file is expected on teardown
-            if (ec.message() != "End of file") {
+            if (ec.message() != s_expected_teardown_message.c_str()) {
               NGRAPH_INFO << "Client error reading body: " << ec.message();
             }
           }
@@ -176,9 +173,9 @@ class TCPClient {
   TCPMessage m_read_message;
   std::deque<ngraph::he::TCPMessage> m_message_queue;
 
-  bool m_first_connect;
+  inline static std::string s_expected_teardown_message{"End of file"};
 
-  // How to handle the message
+  bool m_first_connect;
   std::function<void(const ngraph::he::TCPMessage&)> m_message_callback;
 };
 }  // namespace he

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -132,8 +132,10 @@ class TCPClient {
         m_socket, boost::asio::buffer(m_write_buffer),
         [this](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
+            NGRAPH_INFO << "Done writing message";
             m_message_queue.pop_front();
             if (!m_message_queue.empty()) {
+              NGRAPH_INFO << "Message queue not empty";
               do_write();
             }
           } else {

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -132,10 +132,8 @@ class TCPClient {
         m_socket, boost::asio::buffer(m_write_buffer),
         [this](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
-            NGRAPH_INFO << "Done writing message";
             m_message_queue.pop_front();
             if (!m_message_queue.empty()) {
-              NGRAPH_INFO << "Message queue not empty";
               do_write();
             }
           } else {

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -55,7 +55,7 @@ class TCPClient {
     boost::asio::post(m_io_context, [this]() { m_socket.close(); });
   }
 
-  void write_message(const ngraph::he::TCPMessage& message) {
+  void write_message(const ngraph::he::TCPMessage&& message) {
     bool write_in_progress = !m_message_queue.empty();
     m_message_queue.push_back(message);
     if (!write_in_progress) {

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -34,8 +34,9 @@ namespace ngraph {
 namespace he {
 class TCPClient {
  public:
-  using data_buffer = std::vector<char>;
+  using data_buffer = ngraph::he::TCPMessage::data_buffer;
   size_t header_length = ngraph::he::TCPMessage::header_length;
+
   // Connects client to hostname:port and reads message
   // message_handler will handle responses from the server
   TCPClient(boost::asio::io_context& io_context,
@@ -54,26 +55,9 @@ class TCPClient {
     boost::asio::post(m_io_context, [this]() { m_socket.close(); });
   }
 
-  void write_message(ngraph::he::TCPMessage&& message) {
-    NGRAPH_CHECK(false, "client Writing old message");
-    bool write_in_progress = !m_message_queue.empty();
-    m_message_queue.emplace_back(std::move(message));
-    if (!write_in_progress) {
-      boost::asio::post(m_io_context, [this]() { do_write(); });
-    }
-  }
-
   void write_message(const ngraph::he::TCPMessage& message) {
     bool write_in_progress = !m_message_queue.empty();
     m_message_queue.push_back(message);
-    if (!write_in_progress) {
-      boost::asio::post(m_io_context, [this]() { do_write(); });
-    }
-  }
-
-  void write_message(const ngraph::he::TCPMessage&& message) {
-    bool write_in_progress = !m_message_queue.empty();
-    m_message_queue.emplace_back(std::move(message));
     if (!write_in_progress) {
       boost::asio::post(m_io_context, [this]() { do_write(); });
     }

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -106,7 +106,7 @@ class TCPClient {
         });
   }
 
-  void do_read_body(size_t body_length = 0) {
+  void do_read_body(size_t body_length) {
     NGRAPH_INFO << "Client reading body size " << body_length;
     m_read_buffer.resize(header_length + body_length);
 
@@ -115,7 +115,6 @@ class TCPClient {
         boost::asio::buffer(&m_read_buffer[header_length], body_length),
         [this](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
-            NGRAPH_INFO << "Client read body size " << length << " bytes";
             m_read_message.unpack(m_read_buffer);
             m_message_callback(m_read_message);
             do_read_header();
@@ -128,7 +127,6 @@ class TCPClient {
   }
 
   void do_write() {
-    NGRAPH_INFO << "Client writing message";
     auto message = m_message_queue.front();
     message.pack(m_write_buffer);
 

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -90,9 +90,11 @@ class TCPClient {
   }
 
   void do_read_header() {
-    m_read_buffer.resize(header_length);
+    if (m_read_buffer.size() < header_length) {
+      m_read_buffer.resize(header_length);
+    }
     boost::asio::async_read(
-        m_socket, boost::asio::buffer(m_read_buffer),
+        m_socket, boost::asio::buffer(&m_read_buffer[0], header_length),
         [this](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
@@ -107,7 +109,6 @@ class TCPClient {
 
   void do_read_body(size_t body_length) {
     m_read_buffer.resize(header_length + body_length);
-
     boost::asio::async_read(
         m_socket,
         boost::asio::buffer(&m_read_buffer[header_length], body_length),

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -57,7 +57,7 @@ class TCPClient {
 
   void write_message(const ngraph::he::TCPMessage&& message) {
     bool write_in_progress = !m_message_queue.empty();
-    m_message_queue.push_back(message);
+    m_message_queue.push_back(std::move(message));
     if (!write_in_progress) {
       boost::asio::post(m_io_context, [this]() { do_write(); });
     }

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -107,7 +107,6 @@ class TCPClient {
   }
 
   void do_read_body(size_t body_length) {
-    NGRAPH_INFO << "Client reading body size " << body_length;
     m_read_buffer.resize(header_length + body_length);
 
     boost::asio::async_read(

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -90,15 +90,12 @@ class TCPClient {
   }
 
   void do_read_header() {
-    NGRAPH_INFO << "Client reading header";
     m_read_buffer.resize(header_length);
-
     boost::asio::async_read(
         m_socket, boost::asio::buffer(m_read_buffer),
         [this](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
-            NGRAPH_INFO << "client read header " << msg_len;
             do_read_body(msg_len);
 
           } else {

--- a/src/tcp/tcp_client.hpp
+++ b/src/tcp/tcp_client.hpp
@@ -97,7 +97,6 @@ class TCPClient {
           if (!ec) {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
             do_read_body(msg_len);
-
           } else {
             if (ec.message() != s_expected_teardown_message.c_str()) {
               NGRAPH_INFO << "Client error reading header: " << ec.message();

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -60,7 +60,6 @@ class TCPMessage {
 
   static void encode_header(data_buffer& buffer, size_t size) {
     NGRAPH_CHECK(buffer.size() >= header_length, "Buffer too small");
-    NGRAPH_INFO << "Encoding header " << size;
     std::memcpy(&buffer[0], &size, header_length);
   }
 
@@ -70,7 +69,6 @@ class TCPMessage {
     }
     size_t body_length = 0;
     std::memcpy(&body_length, &buffer[0], header_length);
-    NGRAPH_INFO << "Decoded header body length " << body_length;
     return body_length;
   }
 

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -43,9 +43,11 @@ class TCPMessage {
 
   TCPMessage() = default;
 
-  TCPMessage(he_proto::TCPMessage& proto_message)
-      : m_proto_message(std::make_shared<he_proto::TCPMessage>(proto_message)) {
-  }
+  TCPMessage(he_proto::TCPMessage& proto_message) = delete;
+
+  TCPMessage(he_proto::TCPMessage&& proto_message)
+      : m_proto_message(
+            std::make_shared<he_proto::TCPMessage>(std::move(proto_message))) {}
 
   TCPMessage(std::shared_ptr<he_proto::TCPMessage> proto_message)
       : m_proto_message(proto_message) {}

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -74,7 +74,7 @@ class TCPMessage {
   }
 
   bool pack(data_buffer& buffer) {
-    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empy proto message");
+    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empty proto message");
     size_t msg_size = m_proto_message->ByteSize();
     buffer.resize(header_length + msg_size);
     encode_header(buffer, msg_size);

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -61,7 +61,6 @@ class TCPMessage {
   static void encode_header(data_buffer& buffer, size_t size) {
     NGRAPH_CHECK(buffer.size() >= header_length, "Buffer too small");
     NGRAPH_INFO << "Encoding header " << size;
-
     std::memcpy(&buffer[0], &size, header_length);
   }
 
@@ -71,17 +70,13 @@ class TCPMessage {
     }
     size_t body_length = 0;
     std::memcpy(&body_length, &buffer[0], header_length);
-
     NGRAPH_INFO << "Decoded header body length " << body_length;
     return body_length;
   }
 
   bool pack(data_buffer& buffer) {
     NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empy proto message");
-
     size_t msg_size = m_proto_message->ByteSize();
-    NGRAPH_INFO << "Packing buffer with msg_size " << msg_size;
-
     buffer.resize(header_length + msg_size);
     encode_header(buffer, msg_size);
     return m_proto_message->SerializeToArray(&buffer[header_length], msg_size);
@@ -92,15 +87,9 @@ class TCPMessage {
     if (!m_proto_message) {
       m_proto_message = std::make_shared<he_proto::TCPMessage>();
     }
-
-    NGRAPH_INFO << "Unpacking from buffer sized " << buffer.size();
-
     NGRAPH_CHECK(m_proto_message != nullptr, "Can't unpack empty proot");
-
-    bool status = m_proto_message->ParseFromArray(
-        &buffer[header_length], buffer.size() - header_length);
-    NGRAPH_INFO << "Unpacked";
-    return status;
+    return m_proto_message->ParseFromArray(&buffer[header_length],
+                                           buffer.size() - header_length);
   }
 
  private:

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -74,40 +74,21 @@ class TCPMessage {
   }
 
   bool pack(data_buffer& buffer) {
-    auto t1 = std::chrono::high_resolution_clock::now();
-
-    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empty proto message");
+    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empy proto message");
     size_t msg_size = m_proto_message->ByteSize();
     buffer.resize(header_length + msg_size);
     encode_header(buffer, msg_size);
-    bool ret =
-        m_proto_message->SerializeToArray(&buffer[header_length], msg_size);
-
-    auto t2 = std::chrono::high_resolution_clock::now();
-    NGRAPH_INFO << "pack time "
-                << std::chrono::duration_cast<std::chrono::microseconds>(t2 -
-                                                                         t1)
-                       .count()
-                << "us";
-    return ret;
+    return m_proto_message->SerializeToArray(&buffer[header_length], msg_size);
   }
 
   // buffer => storing proto message
   bool unpack(const data_buffer& buffer) {
-    auto t1 = std::chrono::high_resolution_clock::now();
     if (!m_proto_message) {
       m_proto_message = std::make_shared<he_proto::TCPMessage>();
     }
     NGRAPH_CHECK(m_proto_message != nullptr, "Can't unpack empty proot");
-    bool ret = m_proto_message->ParseFromArray(&buffer[header_length],
-                                               buffer.size() - header_length);
-    auto t2 = std::chrono::high_resolution_clock::now();
-    NGRAPH_INFO << "unpack time "
-                << std::chrono::duration_cast<std::chrono::microseconds>(t2 -
-                                                                         t1)
-                       .count()
-                << "us";
-    return ret;
+    return m_proto_message->ParseFromArray(&buffer[header_length],
+                                           buffer.size() - header_length);
   }
 
  private:

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -74,21 +74,40 @@ class TCPMessage {
   }
 
   bool pack(data_buffer& buffer) {
-    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empy proto message");
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    NGRAPH_CHECK(m_proto_message != nullptr, "Can't pack empty proto message");
     size_t msg_size = m_proto_message->ByteSize();
     buffer.resize(header_length + msg_size);
     encode_header(buffer, msg_size);
-    return m_proto_message->SerializeToArray(&buffer[header_length], msg_size);
+    bool ret =
+        m_proto_message->SerializeToArray(&buffer[header_length], msg_size);
+
+    auto t2 = std::chrono::high_resolution_clock::now();
+    NGRAPH_INFO << "pack time "
+                << std::chrono::duration_cast<std::chrono::microseconds>(t2 -
+                                                                         t1)
+                       .count()
+                << "us";
+    return ret;
   }
 
   // buffer => storing proto message
   bool unpack(const data_buffer& buffer) {
+    auto t1 = std::chrono::high_resolution_clock::now();
     if (!m_proto_message) {
       m_proto_message = std::make_shared<he_proto::TCPMessage>();
     }
     NGRAPH_CHECK(m_proto_message != nullptr, "Can't unpack empty proot");
-    return m_proto_message->ParseFromArray(&buffer[header_length],
-                                           buffer.size() - header_length);
+    bool ret = m_proto_message->ParseFromArray(&buffer[header_length],
+                                               buffer.size() - header_length);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    NGRAPH_INFO << "unpack time "
+                << std::chrono::duration_cast<std::chrono::microseconds>(t2 -
+                                                                         t1)
+                       .count()
+                << "us";
+    return ret;
   }
 
  private:

--- a/src/tcp/tcp_message.hpp
+++ b/src/tcp/tcp_message.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include <algorithm>
 #include <boost/asio.hpp>
 #include <chrono>

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -82,7 +82,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
   }
 
   void write_message(ngraph::he::TCPMessage&& message) {
-    NGRAPH_INFO << "server write  message";
     bool write_in_progress = is_writing();
     m_message_queue.emplace_back(std::move(message));
     if (!write_in_progress) {

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -43,10 +43,12 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
 
  public:
   void do_read_header() {
-    m_read_buffer.resize(header_length);
+    if (m_read_buffer.size() < header_length) {
+      m_read_buffer.resize(header_length);
+    }
     auto self(shared_from_this());
     boost::asio::async_read(
-        m_socket, boost::asio::buffer(m_read_buffer),
+        m_socket, boost::asio::buffer(&m_read_buffer[0], header_length),
         [this, self](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
@@ -59,7 +61,7 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
         });
   }
 
-  void do_read_body(size_t body_length = 0) {
+  void do_read_body(size_t body_length) {
     m_read_buffer.resize(header_length + body_length);
 
     auto self(shared_from_this());

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -52,10 +52,8 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
             do_read_body(msg_len);
           } else {
-            if (ec) {
-              if (ec.message() != s_expected_teardown_message.c_str()) {
-                NGRAPH_INFO << "Server error reading body: " << ec.message();
-              }
+            if (ec.message() != s_expected_teardown_message.c_str()) {
+              NGRAPH_INFO << "Server error reading body: " << ec.message();
             }
           }
         });
@@ -130,6 +128,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
   inline static std::string s_expected_teardown_message{"End of file"};
 
   std::function<void(const ngraph::he::TCPMessage&)> m_message_callback;
-};
+};  // namespace he
 }  // namespace he
 }  // namespace ngraph

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -128,6 +128,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
   inline static std::string s_expected_teardown_message{"End of file"};
 
   std::function<void(const ngraph::he::TCPMessage&)> m_message_callback;
-};  // namespace he
+};
 }  // namespace he
 }  // namespace ngraph

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -62,7 +62,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
   }
 
   void do_read_body(size_t body_length = 0) {
-    NGRAPH_INFO << "server reading body size " << body_length;
     m_read_buffer.resize(header_length + body_length);
 
     auto self(shared_from_this());

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -43,7 +43,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
 
  public:
   void do_read_header() {
-    NGRAPH_INFO << "server do_read_header";
     m_read_buffer.resize(header_length);
     auto self(shared_from_this());
     boost::asio::async_read(
@@ -51,7 +50,6 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
         [this, self](boost::system::error_code ec, std::size_t length) {
           if (!ec) {
             size_t msg_len = m_read_message.decode_header(m_read_buffer);
-            NGRAPH_INFO << "server read hader for msg len " << msg_len;
             do_read_body(msg_len);
           } else {
             if (ec) {
@@ -98,18 +96,11 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
 
  private:
   void do_write() {
-    NGRAPH_INFO << "server do_write";
     std::lock_guard<std::mutex> lock(m_write_mtx);
     m_is_writing.notify_all();
     auto self(shared_from_this());
-
-    NGRAPH_INFO << "m_message_queue.size() " << m_message_queue.size();
-
     auto message = m_message_queue.front();
-
     message.pack(m_write_buffer);
-
-    NGRAPH_INFO << "Buffer size " << m_write_buffer.size();
 
     boost::asio::async_write(
         m_socket, boost::asio::buffer(m_write_buffer),

--- a/src/tcp/tcp_session.hpp
+++ b/src/tcp/tcp_session.hpp
@@ -29,7 +29,7 @@ using boost::asio::ip::tcp;
 namespace ngraph {
 namespace he {
 class TCPSession : public std::enable_shared_from_this<TCPSession> {
-  using data_buffer = std::vector<char>;
+  using data_buffer = ngraph::he::TCPMessage::data_buffer;
   size_t header_length = ngraph::he::TCPMessage::header_length;
 
  public:
@@ -55,8 +55,7 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
             do_read_body(msg_len);
           } else {
             if (ec) {
-              // End of file is expected on teardown
-              if (ec.message() != "End of file") {
+              if (ec.message() != s_expected_teardown_message.c_str()) {
                 NGRAPH_INFO << "Server error reading body: " << ec.message();
               }
             }
@@ -139,7 +138,8 @@ class TCPSession : public std::enable_shared_from_this<TCPSession> {
   std::condition_variable m_is_writing;
   std::mutex m_write_mtx;
 
-  // Called after message is received
+  inline static std::string s_expected_teardown_message{"End of file"};
+
   std::function<void(const ngraph::he::TCPMessage&)> m_message_callback;
 };
 }  // namespace he

--- a/test/test_protobuf.cpp
+++ b/test/test_protobuf.cpp
@@ -131,11 +131,13 @@ TEST(seal_cipher_wrapper, load_save) {
   auto t1 = Clock::now();
   cipher.save(proto_cipher);
   auto t2 = Clock::now();
+  NGRAPH_INFO << "save ok";
 
   std::shared_ptr<ngraph::he::SealCiphertextWrapper> cipher_load;
   auto t3 = Clock::now();
   ngraph::he::SealCiphertextWrapper::load(cipher_load, proto_cipher, context);
   auto t4 = Clock::now();
+  NGRAPH_INFO << "load ok";
 
   std::stringstream ss_load;
   cipher_load->ciphertext().save(ss_load);
@@ -146,10 +148,10 @@ TEST(seal_cipher_wrapper, load_save) {
 
   NGRAPH_INFO
       << "Save time "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count()
-      << "ms";
+      << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()
+      << "us";
   NGRAPH_INFO
       << "Load time "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3).count()
-      << "ms";
+      << std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3).count()
+      << "us";
 }

--- a/test/test_protobuf.cpp
+++ b/test/test_protobuf.cpp
@@ -51,21 +51,18 @@ TEST(tcp_message, create) {
   *proto_msg.mutable_function() = f;
   std::stringstream s;
   proto_msg.SerializeToOstream(&s);
-  ngraph::he::TCPMessage tcp_message(proto_msg);
-
+  ngraph::he::TCPMessage tcp_message(std::move(proto_msg));
   EXPECT_EQ(1, 1);
 }
 
 TEST(tcp_message, encode_decode) {
   using data_buffer = std::vector<char>;
-
   data_buffer buffer;
   buffer.resize(20);
 
   size_t encode_size = 10;
   ngraph::he::TCPMessage::encode_header(buffer, encode_size);
   size_t decoded_size = ngraph::he::TCPMessage::decode_header(buffer);
-
   EXPECT_EQ(decoded_size, encode_size);
 }
 
@@ -78,7 +75,7 @@ TEST(tcp_message, pack_unpack) {
   *proto_msg.mutable_function() = f;
   std::stringstream s;
   proto_msg.SerializeToOstream(&s);
-  ngraph::he::TCPMessage message1(proto_msg);
+  ngraph::he::TCPMessage message1(std::move(proto_msg));
 
   data_buffer buffer;
   message1.pack(buffer);

--- a/test/test_protobuf.cpp
+++ b/test/test_protobuf.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include <google/protobuf/util/message_differencer.h>
+#include <chrono>
 #include <memory>
 
 #include "gtest/gtest.h"
@@ -125,14 +126,30 @@ TEST(seal_cipher_wrapper, load_save) {
   cipher.ciphertext() = c;
   cipher.complex_packing() = true;
   cipher.known_value() = false;
+
+  typedef std::chrono::high_resolution_clock Clock;
+  auto t1 = Clock::now();
   cipher.save(proto_cipher);
+  auto t2 = Clock::now();
 
   std::shared_ptr<ngraph::he::SealCiphertextWrapper> cipher_load;
+  auto t3 = Clock::now();
   ngraph::he::SealCiphertextWrapper::load(cipher_load, proto_cipher, context);
+  auto t4 = Clock::now();
+
   std::stringstream ss_load;
   cipher_load->ciphertext().save(ss_load);
 
   EXPECT_EQ(cipher.complex_packing(), cipher_load->complex_packing());
   EXPECT_EQ(cipher.known_value(), cipher_load->known_value());
   EXPECT_EQ(ss_save.str(), ss_load.str());
+
+  NGRAPH_INFO
+      << "Save time "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count()
+      << "ms";
+  NGRAPH_INFO
+      << "Load time "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3).count()
+      << "ms";
 }

--- a/test/test_protobuf.cpp
+++ b/test/test_protobuf.cpp
@@ -131,13 +131,19 @@ TEST(seal_cipher_wrapper, load_save) {
   auto t1 = Clock::now();
   cipher.save(proto_cipher);
   auto t2 = Clock::now();
-  NGRAPH_INFO << "save ok";
+  NGRAPH_INFO
+      << "Save time "
+      << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()
+      << "us";
 
   std::shared_ptr<ngraph::he::SealCiphertextWrapper> cipher_load;
   auto t3 = Clock::now();
   ngraph::he::SealCiphertextWrapper::load(cipher_load, proto_cipher, context);
   auto t4 = Clock::now();
-  NGRAPH_INFO << "load ok";
+  NGRAPH_INFO
+      << "Load time "
+      << std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3).count()
+      << "us";
 
   std::stringstream ss_load;
   cipher_load->ciphertext().save(ss_load);
@@ -145,13 +151,4 @@ TEST(seal_cipher_wrapper, load_save) {
   EXPECT_EQ(cipher.complex_packing(), cipher_load->complex_packing());
   EXPECT_EQ(cipher.known_value(), cipher_load->known_value());
   EXPECT_EQ(ss_save.str(), ss_load.str());
-
-  NGRAPH_INFO
-      << "Save time "
-      << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count()
-      << "us";
-  NGRAPH_INFO
-      << "Load time "
-      << std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3).count()
-      << "us";
 }

--- a/test/test_server_client.in.cpp
+++ b/test/test_server_client.in.cpp
@@ -614,7 +614,7 @@ NGRAPH_TEST(${BACKEND_NAME},
   float DUMMY_FLOAT = 99;
   copy_data(t_dummy, vector<float>(shape_size(shape_a), DUMMY_FLOAT));
 
-  vector<float> inputs{1, 0, 2, 1, 0, 3, 2, 0, 0, 2, 0, 0};
+  vector<float> inputs{-1, -1, 2, 1, 0, 3, 2, 0, 0, 2, 0, 0};
   vector<float> results;
   auto client_thread = std::thread([&inputs, &results, &batch_size]() {
     auto he_client =
@@ -635,7 +635,7 @@ NGRAPH_TEST(${BACKEND_NAME},
   client_thread.join();
   EXPECT_TRUE(all_close(
       results,
-      test::NDArray<float, 3>({{{1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}})
+      test::NDArray<float, 3>({{{0, 2, 2, 2, 3, 3, 3, 2, 2, 2, 2, 0}}})
           .get_vector(),
       1e-3f));
 }

--- a/test/test_server_client.in.cpp
+++ b/test/test_server_client.in.cpp
@@ -341,6 +341,55 @@ NGRAPH_TEST(${BACKEND_NAME}, server_client_relu_845) {
   EXPECT_TRUE(all_close(results, expected_results, 1e-3f));
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, server_client_relu_10000) {
+  auto backend = runtime::Backend::create("${BACKEND_NAME}");
+  auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());
+
+  size_t batch_size = 1;
+  size_t input_size = 10000;
+
+  Shape shape{batch_size, input_size};
+  auto a = make_shared<op::Parameter>(element::f32, shape);
+  auto relu = make_shared<op::Relu>(a);
+  auto f = make_shared<Function>(relu, ParameterVector{a});
+
+  // Server inputs which are not used
+  auto t_dummy = he_backend->create_plain_tensor(element::f32, shape);
+  auto t_result = he_backend->create_cipher_tensor(element::f32, shape);
+
+  // Used for dummy server inputs
+  float DUMMY_FLOAT = 99;
+  copy_data(t_dummy, vector<float>(input_size, DUMMY_FLOAT));
+
+  vector<float> inputs(input_size);
+  vector<float> expected_results(input_size);
+
+  for (size_t i = 0; i < input_size; ++i) {
+    inputs[i] = (i % 2 == 0) ? i : -i;
+    expected_results[i] = inputs[i] > 0 ? inputs[i] : 0;
+  }
+
+  vector<float> results;
+  auto client_thread = std::thread([&inputs, &results, &batch_size]() {
+    auto he_client =
+        ngraph::he::HESealClient("localhost", 34000, batch_size, inputs);
+
+    while (!he_client.is_done()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    auto double_results = he_client.get_results();
+    results = std::vector<float>(double_results.begin(), double_results.end());
+  });
+
+  auto handle = dynamic_pointer_cast<ngraph::he::HESealExecutable>(
+      he_backend->compile(f));
+  handle->enable_client();
+  handle->call_with_validate({t_result}, {t_dummy});
+
+  client_thread.join();
+  EXPECT_TRUE(all_close(results, expected_results, 1e-3f));
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, server_client_relu_1) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
   auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());

--- a/test/test_server_client.in.cpp
+++ b/test/test_server_client.in.cpp
@@ -318,15 +318,15 @@ auto server_client_relu_packed_test = [](size_t element_count,
   std::shared_ptr<ngraph::Function> f;
   if (bounded) {
     auto bounded_relu_op = make_shared<op::BoundedRelu>(a, bound_value);
-    auto f = make_shared<Function>(bounded_relu_op, ParameterVector{a});
+    f = make_shared<Function>(bounded_relu_op, ParameterVector{a});
   } else {
     auto relu_op = make_shared<op::Relu>(a);
-    auto f = make_shared<Function>(relu_op, ParameterVector{a});
+    f = make_shared<Function>(relu_op, ParameterVector{a});
   }
 
   auto relu = [](double d) { return d > 0 ? d : 0.; };
-  auto bounded_relu = [bound_value](double f) {
-    return f > bound_value ? bound_value : (f > 0) ? f : 0.f;
+  auto bounded_relu = [bound_value](double d) {
+    return d > bound_value ? bound_value : (d > 0) ? d : 0.;
   };
 
   // Server inputs which are not used

--- a/test/test_server_client.in.cpp
+++ b/test/test_server_client.in.cpp
@@ -355,6 +355,10 @@ NGRAPH_TEST(${BACKEND_NAME}, server_client_relu_10000) {
   test_server_client_relu_size(10000);
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, server_client_relu_30000) {
+  test_server_client_relu_size(30000);
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, server_client_pad_relu) {
   auto backend = runtime::Backend::create("${BACKEND_NAME}");
   auto he_backend = static_cast<ngraph::he::HESealBackend*>(backend.get());


### PR DESCRIPTION
* Switched to Protobuf for message serialization, enabling `known_value` max-pool, and `Pad-Relu` ops.
* ~10% performance penalty on MobileNetV2.

WIP. TODO:
  - [x] check client build
  - [x] bounded relu server-client unit-tests
  - [x] parallelize relu
  - [x] add complex packing to serialized ciphertext
 -  [x] unit-tests for saving ciphertext wrappers
 - [x] SealCiphertextWrapper::load to load to `SealCiphertextWrapper&` instead of to `shared_ptr<SealCiphertextWrapper>`? 