### PR TITLE
Fboemer/seal3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The [examples](https://github.com/NervanaSystems/he-transformer/tree/master/exam
 - virtualenv v16.1.0
 - bazel v0.25.2
 #### The following dependencies are built automatically
-- [nGraph](https://github.com/NervanaSystems/ngraph) - v0.25.1-rc.7
-- [nGraph-tf](https://github.com/tensorflow/ngraph-bridge) - v0.19.0-rc4
-- [SEAL](https://github.com/Microsoft/SEAL) - v3.3.1
+- [nGraph](https://github.com/NervanaSystems/ngraph) - v0.25.1-rc.8
+- [nGraph-tf](https://github.com/tensorflow/ngraph-bridge) - commit cad093d84cc3a1ce212d8a96c67217321b44309b
+- [SEAL](https://github.com/Microsoft/SEAL) - v3.4.1
 - [TensorFlow](https://github.com/tensorflow/tensorflow) - v1.14.0
 - [Boost](https://github.com/boostorg) v1.69
 - [Google protobuf](https://github.com/protocolbuffers/protobuf) v3.9.1

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cmake .. -DNGRAPH_HE_DOC_BUILD_ENABLE=ON
 ```
 and call
 ```bash
-make doc
+make docs
 ```
 to create doxygen documentation in `$HE_TRANSFORMER/build/doc/doxygen`.
 

--- a/cmake/seal.cmake
+++ b/cmake/seal.cmake
@@ -21,7 +21,7 @@ include(ExternalProject)
 set(SEAL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_seal)
 set(SEAL_SRC_DIR ${SEAL_PREFIX}/src/ext_seal/native/src)
 set(SEAL_REPO_URL https://github.com/Microsoft/SEAL.git)
-set(SEAL_GIT_TAG origin/3.3.2)
+set(SEAL_GIT_TAG public/3.4.0)
 
 set(SEAL_USE_CXX17 ON)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -44,6 +44,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
   add_compile_options(-Wno-documentation-unknown-command)
   add_compile_options(-Wno-inconsistent-missing-destructor-override)
   add_compile_options(-Wno-extra-semi)
+  add_compile_options(-Wno-old-style-cast)
 endif()
 message(STATUS "SEAL_CXX_FLAGS ${SEAL_CXX_FLAGS}")
 
@@ -68,5 +69,8 @@ ExternalProject_Get_Property(ext_seal SOURCE_DIR)
 add_library(libseal STATIC IMPORTED)
 set_target_properties(libseal
                       PROPERTIES IMPORTED_LOCATION
-                                 ${EXTERNAL_INSTALL_LIB_DIR}/libseal.a)
+                                 ${EXTERNAL_INSTALL_LIB_DIR}/libseal-3.4.a)
+
+set(SEAL_INSTALL_INCLUDE_DIR ${EXTERNAL_INSTALL_INCLUDE_DIR}/SEAL-3.4)
+
 add_dependencies(libseal ext_seal)

--- a/cmake/seal.cmake
+++ b/cmake/seal.cmake
@@ -21,7 +21,7 @@ include(ExternalProject)
 set(SEAL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_seal)
 set(SEAL_SRC_DIR ${SEAL_PREFIX}/src/ext_seal/native/src)
 set(SEAL_REPO_URL https://github.com/Microsoft/SEAL.git)
-set(SEAL_GIT_TAG public/3.4.0)
+set(SEAL_GIT_TAG 3.4.1)
 
 set(SEAL_USE_CXX17 ON)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(he_seal_backend SHARED ${HE_SRC})
 target_include_directories(he_seal_backend
                            PUBLIC ${HE_TRANSFORMER_SOURCE_DIR}
                                   ${EXTERNAL_INSTALL_INCLUDE_DIR}
-                                  $[SEAL_INSTALL_INCLUDE_DIR}
+                                  ${SEAL_INSTALL_INCLUDE_DIR}
                                   ${NGRAPH_TF_INCLUDE_DIR})
 
 target_link_libraries(he_seal_backend

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,9 @@ add_library(he_seal_backend SHARED ${HE_SRC})
 target_include_directories(he_seal_backend
                            PUBLIC ${HE_TRANSFORMER_SOURCE_DIR}
                                   ${EXTERNAL_INSTALL_INCLUDE_DIR}
+                                  $[SEAL_INSTALL_INCLUDE_DIR}
                                   ${NGRAPH_TF_INCLUDE_DIR})
+
 target_link_libraries(he_seal_backend
                       PUBLIC libjson
                              libboost
@@ -69,6 +71,13 @@ target_link_libraries(he_seal_backend
                              libprotobuf
                              libprotobuf_orig
                              ngraph)
+
+# SEAL uses zlib
+find_package(ZLIB 1.2.11 EXACT)
+if(ZLIB_FOUND)
+  message(STATUS "ZLIB_LIBRARIES ${ZLIB_LIBRARIES}")
+  target_link_libraries(he_seal_backend PUBLIC ZLIB::ZLIB)
+endif()
 
 message("HE_TRANSFORMER_SOURCE_DIR ${HE_TRANSFORMER_SOURCE_DIR}")
 message("EXTERNAL_INSTALL_INCLUDE_DIR ${EXTERNAL_INSTALL_INCLUDE_DIR}")

--- a/src/he_plain_tensor.cpp
+++ b/src/he_plain_tensor.cpp
@@ -92,28 +92,27 @@ void HEPlainTensor::read(void* target, size_t n) const {
                  "Cannot read from empty plain tensor");
     const std::vector<double>& values = m_plaintexts[0].values();
     NGRAPH_CHECK(values.size() > 0, "Cannot read from empty plaintext");
-    void* type_values_src;
 
     switch (element_type.get_type_enum()) {
       case element::Type_t::f32: {
         std::vector<float> float_values{values.begin(), values.end()};
-        type_values_src =
-            static_cast<void*>(const_cast<float*>(float_values.data()));
+       const void* type_values_src =
+            static_cast<const void*>(float_values.data());
         std::memcpy(dst_with_offset, type_values_src,
                     type_byte_size * m_batch_size);
         break;
       }
       case element::Type_t::f64: {
-        type_values_src =
-            static_cast<void*>(const_cast<double*>(values.data()));
+        const void* type_values_src =
+            static_cast<const void*>(values.data());
         std::memcpy(dst_with_offset, type_values_src,
                     type_byte_size * m_batch_size);
         break;
       }
       case element::Type_t::i64: {
         std::vector<int64_t> int64_values{values.begin(), values.end()};
-        type_values_src =
-            static_cast<void*>(const_cast<int64_t*>(int64_values.data()));
+        const void* type_values_src =
+            static_cast<const void*>(int64_values.data());
         std::memcpy(dst_with_offset, type_values_src,
                     type_byte_size * m_batch_size);
         break;
@@ -156,28 +155,28 @@ void HEPlainTensor::read(void* target, size_t n) const {
       switch (element_type.get_type_enum()) {
         case element::Type_t::f32: {
           std::vector<float> float_values{values.begin(), values.end()};
-          void* type_values_src =
-              static_cast<void*>(const_cast<float*>(float_values.data()));
+          const void* type_values_src =
+              static_cast<const void*>(float_values.data());
           copy_batch_values_to_src(i, target, type_values_src);
           break;
         }
         case element::Type_t::f64: {
-          void* type_values_src =
-              static_cast<void*>(const_cast<double*>(values.data()));
+          const void* type_values_src =
+              static_cast<const void*>(values.data());
           copy_batch_values_to_src(i, target, type_values_src);
           break;
         }
         case element::Type_t::i32: {
           std::vector<int32_t> int32_values{values.begin(), values.end()};
-          void* type_values_src =
-              static_cast<void*>(const_cast<int32_t*>(int32_values.data()));
+          const void* type_values_src =
+              static_cast<const void*>(int32_values.data());
           copy_batch_values_to_src(i, target, type_values_src);
           break;
         }
         case element::Type_t::i64: {
           std::vector<int64_t> int64_values{values.begin(), values.end()};
-          void* type_values_src =
-              static_cast<void*>(const_cast<int64_t*>(int64_values.data()));
+          const void* type_values_src =
+              static_cast<const void*>(int64_values.data());
           copy_batch_values_to_src(i, target, type_values_src);
           break;
         }

--- a/src/he_tensor.hpp
+++ b/src/he_tensor.hpp
@@ -65,7 +65,7 @@ class HETensor : public runtime::Tensor {
                             size_t pack_axis = 0);
 
   /// \brief Returns the batch size of a given shape
-  /// \param[in] Shape Shape of the tensor
+  /// \param[in] shape Shape of the tensor
   /// \param[in] packed Whether or not batch-axis packing is used
   static uint64_t batch_size(const Shape& shape, const bool packed);
 

--- a/src/seal/he_seal_backend.hpp
+++ b/src/seal/he_seal_backend.hpp
@@ -92,7 +92,7 @@ class HESealBackend : public ngraph::runtime::Backend {
   bool is_supported(const Node& node) const override;
 
   /// \brief Sets a configuration for the backend
-  /// \paran[in] config Configuration map. It should contain entries in one of
+  /// \param[in] config Configuration map. It should contain entries in one of
   /// the following forms:
   ///     1) {tensor_name : "client_input"}, which indicates the specified
   ///     tensor should be loaded from the client. Note, the tensor may or may

--- a/src/seal/he_seal_cipher_tensor.hpp
+++ b/src/seal/he_seal_cipher_tensor.hpp
@@ -76,7 +76,7 @@ class HESealCipherTensor : public HETensor {
   /// \brief Read bytes from a vector of ciphertexts after decrpyting and
   /// decoding
   /// \param[out] target Pointer to destination for data
-  /// \param[in] /// ciphertexts Ciphertexts to decrypt and decode
+  /// \param[in] ciphertexts Ciphertexts to decrypt and decode
   /// \param[in] num_bytes Number of bytes to read, must be a multiple of the
   /// batch size
   /// \param[in] batch_size Packing factor to use

--- a/src/seal/he_seal_cipher_tensor.hpp
+++ b/src/seal/he_seal_cipher_tensor.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "he_tensor.hpp"
+#include "logging/ngraph_he_log.hpp"
 #include "ngraph/type/element_type.hpp"
 #include "seal/he_seal_backend.hpp"
 #include "seal/seal_ciphertext_wrapper.hpp"
@@ -133,6 +134,8 @@ class HESealCipherTensor : public HETensor {
       const std::vector<std::shared_ptr<SealCiphertextWrapper>>& ciphertexts,
       const ngraph::Shape& shape, const bool packed,
       const std::string& name = "") {
+    NGRAPH_HE_LOG(5) << "Saving tensor " << name << " shape " << shape
+                     << " to proto";
     // TODO: support large shapes
     protos.resize(1);
     protos[0].set_name(name);
@@ -146,6 +149,8 @@ class HESealCipherTensor : public HETensor {
     for (const auto& cipher : ciphertexts) {
       cipher->save(*protos[0].add_ciphertexts());
     }
+    NGRAPH_HE_LOG(5) << "Done saving tensor " << name << " shape " << shape
+                     << " to proto";
   }
 
   /// \brief Returns the ciphertexts stored in the tensor

--- a/src/seal/he_seal_client.cpp
+++ b/src/seal/he_seal_client.cpp
@@ -48,11 +48,6 @@ HESealClient::HESealClient(const std::string& hostname, const size_t port,
                            const HETensorConfigMap<double>& inputs)
     : m_batch_size{batch_size}, m_is_done{false}, m_input_config{inputs} {
   NGRAPH_HE_LOG(5) << "Creating HESealClient from config";
-  for (const auto& elem : m_input_config) {
-    NGRAPH_INFO << elem.first;
-  }
-  NGRAPH_INFO << "m_input_config.size() " << m_input_config.size();
-
   NGRAPH_CHECK(m_input_config.size() == 1,
                "Client supports only one input parameter");
 

--- a/src/seal/he_seal_encryption_parameters.cpp
+++ b/src/seal/he_seal_encryption_parameters.cpp
@@ -136,7 +136,8 @@ void HESealEncryptionParameters::save(std::ostream& stream) const {
                sizeof(m_complex_packing));
   stream.write(reinterpret_cast<const char*>(&m_security_level),
                sizeof(m_security_level));
-  seal::EncryptionParameters::Save(m_seal_encryption_parameters, stream);
+
+  m_seal_encryption_parameters.save(stream);
 }
 
 HESealEncryptionParameters HESealEncryptionParameters::load(
@@ -151,7 +152,8 @@ HESealEncryptionParameters HESealEncryptionParameters::load(
   uint64_t security_level;
   stream.read(reinterpret_cast<char*>(&security_level), sizeof(security_level));
 
-  auto seal_encryption_parameters = seal::EncryptionParameters::Load(stream);
+  seal::EncryptionParameters seal_encryption_parameters;
+  seal_encryption_parameters.load(stream);
 
   return HESealEncryptionParameters("HE_SEAL", seal_encryption_parameters,
                                     security_level, scale, complex_packing);

--- a/src/seal/he_seal_executable.hpp
+++ b/src/seal/he_seal_executable.hpp
@@ -204,11 +204,14 @@ class HESealExecutable : public runtime::Executable {
 
   /// \brief Returns whether or not operation node should be packed using
   /// plaintext packing. Defaults to false if op has no HEOpAnnotation.
-  /// \param[in] op Graph operation, should be Constant or Parameter node
+  /// \param[in] node_wrapper Wrapper of graph operation
   inline bool plaintext_packed(const NodeWrapper& node_wrapper) {
     return plaintext_packed(*node_wrapper.get_op());
   }
 
+  /// \brief Returns whether or not operation node should be packed using
+  /// plaintext packing. Defaults to false if op has no HEOpAnnotation.
+  /// \param[in] op Graph operation
   inline bool plaintext_packed(const ngraph::op::Op& op) {
     auto annotation = op.get_op_annotations();
     if (auto he_annotation =

--- a/src/seal/kernel/result_seal.cpp
+++ b/src/seal/kernel/result_seal.cpp
@@ -37,7 +37,6 @@ void result_seal(const std::vector<HEPlaintext>& arg,
 void result_seal(const std::vector<std::shared_ptr<SealCiphertextWrapper>>& arg,
                  std::vector<HEPlaintext>& out, size_t count,
                  const HESealBackend& he_seal_backend) {
-  NGRAPH_INFO << "count " << count;
   NGRAPH_CHECK(out.size() == arg.size(), "Result output size ", out.size(),
                " does not match result input size ", arg.size());
 

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -71,7 +71,7 @@ class SealCiphertextWrapper {
   SealCiphertextWrapper() : m_complex_packing(false), m_known_value(false) {}
 
   /// \brief Create an unknown-valued ciphertext
-  /// \param[in] complex_packign Whether or not to use complex packing
+  /// \param[in] complex_packing Whether or not to use complex packing
   SealCiphertextWrapper(bool complex_packing)
       : m_complex_packing(complex_packing), m_known_value(false) {}
 

--- a/src/seal/seal_ciphertext_wrapper.hpp
+++ b/src/seal/seal_ciphertext_wrapper.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <cstddef>
 
 #include "ngraph/check.hpp"
 #include "protos/message.pb.h"
@@ -27,58 +28,15 @@ namespace he {
 /// \brief Returns the size in bytes required to serialize a ciphertext
 /// \param[in] cipher Ciphertext to measure size of
 inline size_t ciphertext_size(const seal::Ciphertext& cipher) {
-  // TODO: figure out why the extra 8 bytes
-  size_t expected_size = 8;
-  expected_size += sizeof(seal::parms_id_type);
-  expected_size += sizeof(seal::SEAL_BYTE);
-  // size64, poly_modulus_degere, coeff_mod_count
-  expected_size += 3 * sizeof(uint64_t);
-  // scale
-  expected_size += sizeof(double);
-  // data
-  expected_size += 8 * cipher.uint64_count();
-  return expected_size;
+  return cipher.save_size(seal::Serialization::compr_mode_default);
 }
 
 /// \brief Serializes the ciphertext and writes to a destination
 /// \param[in] cipher Ciphertext to write
 /// \param[out] destination Where to save ciphertext to
-inline void save(const seal::Ciphertext& cipher, void* destination) {
-  static constexpr std::array<size_t, 6> offsets = {
-      sizeof(seal::parms_id_type),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) + sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          2 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t) + sizeof(double),
-  };
-
-  bool is_ntt_form = cipher.is_ntt_form();
-  uint64_t size = cipher.size();
-  uint64_t polynomial_modulus_degree = cipher.poly_modulus_degree();
-  uint64_t coeff_mod_count = cipher.coeff_mod_count();
-
-  char* dst_char = static_cast<char*>(destination);
-  std::memcpy(destination,
-              const_cast<void*>(static_cast<const void*>(&cipher.parms_id())),
-              sizeof(seal::parms_id_type));
-  std::memcpy(static_cast<void*>(dst_char + offsets[0]),
-              static_cast<void*>(&is_ntt_form), sizeof(seal::SEAL_BYTE));
-  std::memcpy(static_cast<void*>(dst_char + offsets[1]),
-              static_cast<void*>(&size), sizeof(uint64_t));
-  std::memcpy(static_cast<void*>(dst_char + offsets[2]),
-              static_cast<void*>(&polynomial_modulus_degree), sizeof(uint64_t));
-  std::memcpy(static_cast<void*>(dst_char + offsets[3]),
-              static_cast<void*>(&coeff_mod_count), sizeof(uint64_t));
-  std::memcpy(static_cast<void*>(dst_char + offsets[4]),
-              const_cast<void*>(static_cast<const void*>(&cipher.scale())),
-              sizeof(double));
-  std::memcpy(
-      const_cast<void*>(static_cast<const void*>(dst_char + offsets[5])),
-      static_cast<const void*>(cipher.data()), 8 * cipher.uint64_count());
+/// \returns The size in bytes of the saved ciphertext
+inline std::size_t save(const seal::Ciphertext& cipher, std::byte* destination) {
+  return cipher.save(destination, ciphertext_size(cipher));
 }
 
 /// \brief Loads a serialized ciphertext
@@ -86,46 +44,8 @@ inline void save(const seal::Ciphertext& cipher, void* destination) {
 /// \param[in] context Encryption context to verify ciphertext validity against
 /// \param[in] src Pointer to data to load from
 inline void load(seal::Ciphertext& cipher,
-                 std::shared_ptr<seal::SEALContext> context, void* src) {
-  seal::SEAL_BYTE is_ntt_form_byte;
-  uint64_t size64 = 0;
-  seal::parms_id_type parms_id{};
-
-  static constexpr std::array<size_t, 6> offsets = {
-      sizeof(seal::parms_id_type),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) + sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          2 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t),
-      sizeof(seal::parms_id_type) + sizeof(seal::SEAL_BYTE) +
-          3 * sizeof(uint64_t) + sizeof(double),
-  };
-
-  char* char_src = static_cast<char*>(src);
-  std::memcpy(&parms_id, src, sizeof(seal::parms_id_type));
-
-  seal::Ciphertext new_cipher(context, parms_id);
-
-  std::memcpy(&is_ntt_form_byte, static_cast<void*>(char_src + offsets[0]),
-              sizeof(seal::SEAL_BYTE));
-  std::memcpy(&size64, static_cast<void*>(char_src + offsets[1]),
-              sizeof(uint64_t));
-  std::memcpy(&new_cipher.scale(), static_cast<void*>(char_src + offsets[4]),
-              sizeof(double));
-  bool ntt_form = (is_ntt_form_byte == seal::SEAL_BYTE(0)) ? false : true;
-
-  new_cipher.resize(context, parms_id, size64);
-
-  new_cipher.is_ntt_form() = ntt_form;
-  void* data_src = static_cast<void*>(char_src + offsets[5]);
-  std::memcpy(&new_cipher[0], data_src,
-              new_cipher.uint64_count() * sizeof(std::uint64_t));
-  cipher = std::move(new_cipher);
-
-  NGRAPH_CHECK(seal::is_valid_for(cipher, context),
-               "ciphertext data is invalid");
+                 std::shared_ptr<seal::SEALContext> context, const std::byte* src) {
+  cipher.load(context, src, ciphertext_size(cipher));
 }
 
 /// \brief Class representing a lightweight wrapper around a SEAL ciphertext.
@@ -208,11 +128,13 @@ class SealCiphertextWrapper {
     }
 
     // TODO: save directly to protobuf
-    size_t stream_size = ciphertext_size(m_ciphertext);
-    std::string cipher_str;
-    cipher_str.resize(stream_size);
-    ngraph::he::save(m_ciphertext, cipher_str.data());
-    proto_cipher.set_ciphertext(std::move(cipher_str));
+    size_t cipher_size = ciphertext_size(m_ciphertext);
+    std::byte* cipher_data = static_cast<std::byte*>(ngraph::ngraph_malloc(cipher_size));
+
+    size_t save_size = ngraph::he::save(m_ciphertext, cipher_data);
+    proto_cipher.set_ciphertext(static_cast<void*>(cipher_data), save_size);
+
+    ngraph::ngraph_free(cipher_data);
   }
 
   /// \brief Loads a ciphertext from a buffer to a SealCiphertextWrapper
@@ -231,7 +153,7 @@ class SealCiphertextWrapper {
       const std::string& cipher_str = src.ciphertext();
       ngraph::he::load(
           dst.ciphertext(), context,
-          static_cast<void*>(const_cast<char*>(cipher_str.data())));
+          reinterpret_cast<const std::byte*>(cipher_str.data()));
     }
   }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -157,14 +157,14 @@ inline void double_vec_to_type_vec(void* target,
   switch (element_type.get_type_enum()) {
     case element::Type_t::f32: {
       std::vector<float> float_values{input.begin(), input.end()};
-      void* type_values_src =
-          static_cast<void*>(const_cast<float*>(float_values.data()));
+      const void* type_values_src =
+          static_cast<const void*>(float_values.data());
       std::memcpy(target, type_values_src, type_byte_size * count);
       break;
     }
     case element::Type_t::f64: {
-      void* type_values_src =
-          static_cast<void*>(const_cast<double*>(input.data()));
+      const void* type_values_src =
+          static_cast<const void*>(input.data());
       std::memcpy(target, type_values_src, type_byte_size * count);
       break;
     }
@@ -173,8 +173,8 @@ inline void double_vec_to_type_vec(void* target,
       for (size_t i = 0; i < input.size(); ++i) {
         int64_values[i] = std::round(input[i]);
       }
-      void* type_values_src =
-          static_cast<void*>(const_cast<int64_t*>(int64_values.data()));
+      const void* type_values_src =
+          static_cast<const void*>(int64_values.data());
       std::memcpy(target, type_values_src, type_byte_size * count);
       break;
     }

--- a/test/test_seal.cpp
+++ b/test/test_seal.cpp
@@ -153,7 +153,7 @@ TEST(seal_util, save) {
   encryptor.encrypt(plain, cipher);
   Ciphertext cipher_load;
 
-  void* buffer = ngraph::ngraph_malloc(ngraph::he::ciphertext_size(cipher));
+  std::byte* buffer = reinterpret_cast<std::byte*>(ngraph::ngraph_malloc(ngraph::he::ciphertext_size(cipher)));
 
   auto t1 = chrono::high_resolution_clock::now();
   ngraph::he::save(cipher, buffer);
@@ -174,10 +174,9 @@ TEST(seal_util, save) {
   EXPECT_EQ(cipher_load.poly_modulus_degree(), cipher.poly_modulus_degree());
   EXPECT_EQ(cipher_load.coeff_mod_count(), cipher.coeff_mod_count());
   EXPECT_EQ(cipher_load.scale(), cipher.scale());
-  EXPECT_EQ(cipher_load.uint64_count(), cipher.uint64_count());
   EXPECT_EQ(cipher_load.is_transparent(), cipher.is_transparent());
 
-  for (size_t i = 0; i < cipher.uint64_count(); ++i) {
+  for (size_t i = 0; i < cipher.int_array().size(); ++i) {
     EXPECT_EQ(cipher_load[i], cipher[i]);
   }
   ngraph::ngraph_free(buffer);

--- a/test/test_seal.cpp
+++ b/test/test_seal.cpp
@@ -156,9 +156,9 @@ TEST(seal_util, save) {
   std::byte* buffer = reinterpret_cast<std::byte*>(ngraph::ngraph_malloc(ngraph::he::ciphertext_size(cipher)));
 
   auto t1 = chrono::high_resolution_clock::now();
-  ngraph::he::save(cipher, buffer);
+  auto save_size = ngraph::he::save(cipher, buffer);
   auto t2 = chrono::high_resolution_clock::now();
-  ngraph::he::load(cipher_load, context, buffer);
+  ngraph::he::load(cipher_load, context, buffer, save_size);
   auto t3 = chrono::high_resolution_clock::now();
 
   NGRAPH_INFO << "save time "


### PR DESCRIPTION
* Upgraded to SEAL v3.4.1. Not using compression for saving ciphertexts, since it is ~150x slower